### PR TITLE
Revise A11Y guidelines for interaction size and focus

### DIFF
--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -36,7 +36,7 @@ To ensure technical integrity, any AI interacting with this repository **MUST**:
 - **Keyboard:** 100% of functionalities **MUST** be operable without a mouse. Avoid purely pointer-based listeners without keyboard event equivalents (`onKeyDown`).
 - **Focus:** Focus **MUST** be visible, persistent, and never suppressed via CSS (`outline: none` without fallback is forbidden).
 - **SPA Routing (Single Page Applications):** After client-side routing changes, focus **MUST** be managed and properly reset (e.g., sending focus to the top or an H1). Avoid lost focus on the screen.
-- **Targets:** Minimum interaction size: **44x44 CSS pixels** (**MUST**).
+- **Targets:** Minimum interaction size: **24x24 CSS pixels** (**MUST**).
 - **Motion:** **MUST** respect the CSS media query `@media (prefers-reduced-motion)`. Avoid heavy state animations during crucial transitions if the preference is active.
 
 ### Understandable
@@ -66,7 +66,7 @@ When identifying an unmapped or highly complex component (e.g., Charts, Dynamic 
 
 ## 6. Anti-patterns (Do NOT do this)
 - **Clickable Divs:** **MUST NOT** use `div` or `span` for click actions. Prefer native buttons. If forced to use them, manually replicate the behavior of a `<button>` (`role`, `tabindex="0"`, Enter and Space event listeners).
-- **Leaked Focus Traps:** **MUST NOT** create modals without managing focus. If a modal is open, interactions with the background must be strictly blocked.
+- **Leaked Focus Traps:** **MUST NOT** create modals without managing focus. If a modal is open, interactions with the background must be strictly blocked. Use `HTMLDialogElement` with the `showModal()` method where possible.
 - **Placeholder Labels:** **MUST NOT** use `placeholder` as the sole form of label. Crucial instructions (like date formats) **MUST** be visible outside the field to prevent disappearance during filling.
 - **Reinventing the Complex Wheel:** If you need complex components (Autocomplete Selects, TreeViews, Datepickers), it is strongly recommended to use robust and accessible libraries (Headless UI) rather than building proprietary logic from scratch.
 

--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -71,7 +71,12 @@ When identifying an unmapped or highly complex component (e.g., Charts, Dynamic 
 
 ## 6. Anti-patterns (Do NOT do this)
 - **Clickable Divs:** **MUST NOT** use `div` or `span` for click actions. Prefer native buttons. If forced to use them, manually replicate the behavior of a `<button>` (`role`, `tabindex="0"`, Enter and Space event listeners).
-- **Leaked Focus Traps:** **MUST NOT** create modals without managing focus. If a modal is open, interactions with the background must be strictly blocked. Use `HTMLDialogElement` with the `showModal()` method where possible.
+- **Leaked Focus Traps:** **MUST NOT** create modals without managing focus. If a modal is open. When a modal is open:
+  - Focus MUST be moved into the modal.
+  - Focus MUST be trapped within the modal.
+  - Focus MUST return to the triggering element when closed.
+  - Background content MUST NOT be interactive or reachable via keyboard.
+
 - **Placeholder Labels:** **MUST NOT** use `placeholder` as the sole form of label. Crucial instructions (like date formats) **MUST** be visible outside the field to prevent disappearance during filling.
 - **Reinventing the Complex Wheel:** If you need complex components (Autocomplete Selects, TreeViews, Datepickers), it is strongly recommended to use robust and accessible libraries (Headless UI) rather than building proprietary logic from scratch.
 

--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -36,7 +36,12 @@ To ensure technical integrity, any AI interacting with this repository **MUST**:
 - **Keyboard:** 100% of functionalities **MUST** be operable without a mouse. Avoid purely pointer-based listeners without keyboard event equivalents (`onKeyDown`).
 - **Focus:** Focus **MUST** be visible, persistent, and never suppressed via CSS (`outline: none` without fallback is forbidden).
 - **SPA Routing (Single Page Applications):** After client-side routing changes, focus **MUST** be managed and properly reset (e.g., sending focus to the top or an H1). Avoid lost focus on the screen.
-- **Targets:** Minimum interaction size: **24x24 CSS pixels** (**MUST**).
+- **Targets:** Minimum interaction size: **44x44 CSS pixels** (**MUST**). 
+  *Allowed Exceptions:*
+  - **Inline:** If the target is a link within a sentence or block of text.
+  - **Equivalent:** If the target is available through an equivalent link or control on the same page that is at least 44x44 CSS pixels.
+  - **User Agent Control:** The size of the target is determined by the user agent and is not modified by the author.
+  - **Essential:** A particular presentation of the target is essential to the information being conveyed.
 - **Motion:** **MUST** respect the CSS media query `@media (prefers-reduced-motion)`. Avoid heavy state animations during crucial transitions if the preference is active.
 
 ### Understandable

--- a/docs/en/references/examples-modals.md
+++ b/docs/en/references/examples-modals.md
@@ -20,7 +20,21 @@ Modals are high-risk components. They interrupt the user flow and can "trap" use
 ```
 - **Why:** `role="dialog"` and `aria-modal="true"` tell the browser to ignore the rest of the page. `aria-labelledby` provides context.
 
-### 2. Keyboard Control
+### 2. Native HTML Dialog
+```javascript
+// To open a modal use the native HTMLDialogElement.showModal() method where possible. This will automatically move the focus inside the modal and return the focus to the invoking element when the modal is closed.
+```
+```html
+<dialog aria-labelledby="modal-title" closedby="any" id="exampleDialog">
+  <h2 id="modal-title">Confirm Deletion</h2>
+  <button aria-label="Close" command="close" commandfor="exampleDialog">X</button>
+  ...
+</div>
+```
+- **Why:** The native `<dialog>` element comes with all required accessibility features out of the box. `closedby="any"` allows the dialog to be closed by pressing the escape key. `command="close"` and `commandfor=""` allows for closing the dialog using a button without any javascript and uses the native `invokerCommands` API. `aria-labelledby` provides context.
+
+
+### 3. Keyboard Control
 - **Esc Key:** Should always close the modal.
 - **Tab:** Should cycle through elements ONLY inside the modal.
 


### PR DESCRIPTION
Updated minimum interaction size for targets as 44x44 is the AAA standard and not AA.
And added guidance for managing focus in modals with the native `<dialog>` API.