### PR TITLE
docs: add upstream fallback for reference links in single-file installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ We treat `.gitignore`, `eslint`, and `CLAUDE.md` as canonical truths in our repo
 
 Reading about accessibility is the first step, injecting it into your code is the real goal. Do this **right now** in your project:
 
-1. **Download the Standard:** Copy the `docs/en/A11Y.md` file into your application's repository. (It can be placed in the root, inside a `docs/` folder, or anywhere else).
+1. **Download the Standard:** Copy the `docs/en/A11Y.md` file into your application's repository. (It can be placed in the root, inside a `docs/` folder, or anywhere else). Optionally, also copy the `references/` and `templates/` folders next to it to keep the deep-dive guides available offline; if you skip them, the AI falls back to the guides in this repository via their upstream URLs.
 2. **Inject the Command:** You must explicitly instruct your AI to read it. If you use a `.cursorrules` or `CLAUDE.md` file, add this directive:
    > *"When developing the frontend, follow strictly the development rules defined in the A11Y.md file."*
 3. **Set the Profile:** The AI will proactively ask you which Compliance Profile (Shield, Standard, or Launchpad) to use if you don't specify one.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -38,7 +38,7 @@ Nós tratamos arquivos como `.gitignore`, `eslint` e `CLAUDE.md` como verdades c
 
 Ler sobre acessibilidade é o primeiro passo, injetá-la no código é o objetivo real. Faça isto **agora** no seu projeto:
 
-1. **Baixe o Padrão:** Copie o arquivo `docs/pt-BR/A11Y.md` para o repositório da sua aplicação. (Ele pode ser colocado na raiz, dentro de uma pasta `docs/`, ou em qualquer outro lugar).
+1. **Baixe o Padrão:** Copie o arquivo `docs/pt-BR/A11Y.md` para o repositório da sua aplicação. (Ele pode ser colocado na raiz, dentro de uma pasta `docs/`, ou em qualquer outro lugar). Opcionalmente, copie também as pastas `references/` e `templates/` junto dele para manter os guias detalhados disponíveis offline; se você não copiá-las, a IA usa como fallback os guias deste repositório via URLs upstream.
 2. **Injete o Comando:** Você precisa instruir explicitamente a sua IA a lê-lo. Se você usa um arquivo `.cursorrules` ou `CLAUDE.md`, adicione esta diretiva:
    > *"Ao desenvolver o frontend, siga estritamente as regras de desenvolvimento definidas no arquivo A11Y.md."*
 3. **Defina o Perfil:** A IA perguntará proativamente qual Compliance Profile (Shield, Standard ou Launchpad) ela deve usar, caso você não tenha especificado.

--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -36,7 +36,7 @@ Evaluate the impact of any design or implementation decision following these lev
 ## 2. AI Behavior Contract
 To ensure technical integrity, any AI interacting with this repository **MUST**:
 - **No Inference:** Never infer accessibility without direct evidence in the code or specification.
-- **Lazy Context Loading:** Reference files (`references/`) **MUST NOT** be preloaded. They **MUST** be consulted only when the task explicitly involves that component type. The `A11Y.md` alone is sufficient for most code generation tasks.
+- **Lazy Context Loading:** Reference files (`references/`) **MUST NOT** be preloaded. They **MUST** be consulted only when the task explicitly involves that component type. The `A11Y.md` alone is sufficient for most code generation tasks. If the `references/` and `templates/` folders are not available locally (e.g., only this file was copied into the project), resolve the relative links against the upstream repository: `https://github.com/fecarrico/A11Y.md/tree/main/docs/en/`.
 - **Reference APG:** Prioritize patterns from the [WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/).
 - **Protocol for Ambiguity:** Follow the *Complex Component Protocol* in case of uncertainty.
 - **Explain Trade-offs:** Explain impacts on Accessibility vs UX vs Business when suggesting changes.

--- a/docs/pt-BR/A11Y.md
+++ b/docs/pt-BR/A11Y.md
@@ -36,7 +36,7 @@ Avalie o impacto de qualquer decisão de design ou implementação seguindo este
 ## 2. AI Behavior Contract
 Para garantir a integridade técnica, qualquer IA interagindo com este repositório **MUST**:
 - **No Inference:** Nunca inferir acessibilidade sem evidência direta no código ou especificação.
-- **Lazy Context Loading:** Os arquivos de referência (`references/`) **MUST NOT** ser carregados preventivamente. Eles **MUST** ser consultados apenas quando a tarefa envolver explicitamente aquele tipo de componente. O `A11Y.md` sozinho é suficiente para a maioria das tarefas de geração de código.
+- **Lazy Context Loading:** Os arquivos de referência (`references/`) **MUST NOT** ser carregados preventivamente. Eles **MUST** ser consultados apenas quando a tarefa envolver explicitamente aquele tipo de componente. O `A11Y.md` sozinho é suficiente para a maioria das tarefas de geração de código. Se as pastas `references/` e `templates/` não estiverem disponíveis localmente (ex.: apenas este arquivo foi copiado para o projeto), resolva os links relativos contra o repositório upstream: `https://github.com/fecarrico/A11Y.md/tree/main/docs/pt-BR/`.
 - **Reference APG:** Priorize padrões do [WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/).
 - **Protocol for Ambiguity:** Siga o *Complex Component Protocol* em caso de incerteza.
 - **Explain Trade-offs:** Explique os impactos em Acessibilidade vs UX vs Negócio ao sugerir alterações.


### PR DESCRIPTION
## Problem

The README Quick Start (step 1) recommends copying **only** `docs/<lang>/A11Y.md` into the consumer's repository. But the file's *Lazy Context Loading* rule tells the AI that reference files "**MUST** be consulted" via relative links (`references/guide-*.md`, `templates/REPORT.md`) that do not exist in that scenario, so the lazy-loading step has nothing to resolve against.

The wiki ([Setup and Integration](https://github.com/fecarrico/A11Y.md/wiki/Setup-and-Integration)) correctly says the AI loads references on demand, but that assumes the references are reachable from the consumer repo.

## Solution

- Add an explicit fallback to the *Lazy Context Loading* bullet in `docs/en/A11Y.md` and `docs/pt-BR/A11Y.md`: when `references/` and `templates/` are not present locally, resolve the relative links against the upstream repository URLs.
- Mention in both READMEs (Quick Start step 1) that copying `references/` and `templates/` alongside `A11Y.md` is optional, and what happens when you skip them.

Keeps the single-file install (the simplest onboarding path) fully functional without forcing anyone to vendor the whole guide library.

Made with [Cursor](https://cursor.com)