### PR TITLE
docs: consolidate the minimum font size rule between Sections 0.1 and 4

### DIFF
--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -79,8 +79,8 @@ To ensure technical integrity, any AI interacting with this repository **MUST**:
 ## 4. Visual Directives (Strict UI Criteria)
 To ensure certification, these visual guidelines are non-negotiable:
 - **Focus Indicator:** The focus ring **MUST** have a minimum thickness of 2px and a contrast of at least 3:1 against the background.
-- **Typography:** Text **MUST NOT** be smaller than 12px.
-    - *Density Exception:* In complex dashboards or secondary metadata (badges), **min 10px** is allowed, provided the contrast is raised to **7:1 (WCAG AAA)** to compensate for the scale.
+- **Typography:** Text **MUST NOT** be smaller than the minimum font size of the active Compliance Profile (Section 0.1); 12px under the default Standard (AA).
+    - *Density Exception:* In complex dashboards or secondary metadata (badges), **min 10px** is allowed, provided the contrast is raised to **7:1 (WCAG AAA)** to compensate for the scale and the relaxation is documented in `EXCEPTIONS.md`, the same logging rule that applies to profile-level relaxations (Section 0.1).
 - **Target Spacing & Hit Area:** See *Section 3 — Targets* for the minimum size rule and exceptions. In dense UIs (e.g., tables), if the visual size is smaller than 44px, the **hit area** (invisible clickable area) **MUST** be expanded via CSS/padding. Adjacent targets **SHOULD** have 8px of spacing.
 
 ## 5. Complex Component Protocol

--- a/docs/pt-BR/A11Y.md
+++ b/docs/pt-BR/A11Y.md
@@ -80,8 +80,8 @@ Para garantir a integridade técnica, qualquer IA interagindo com este repositó
 ## 4. Visual Directives (Critérios Rígidos de UI)
 Para garantir a certificação, estas diretrizes visuais são inegociáveis:
 - **Focus Indicator:** O anel de foco **MUST** ter uma espessura mínima de 2px e um contraste de pelo menos 3:1 em relação ao fundo.
-- **Typography:** O texto **MUST NOT** ser menor que 12px.
-    - *Exceção de Densidade:* Em dashboards complexos ou metadados secundários (badges), permite-se **min 10px**, desde que o contraste seja elevado para **7:1 (WCAG AAA)** para compensar a escala.
+- **Typography:** O texto **MUST NOT** ser menor que a fonte mínima do Compliance Profile ativo (Seção 0.1); 12px no padrão Standard (AA).
+    - *Exceção de Densidade:* Em dashboards complexos ou metadados secundários (badges), permite-se **min 10px**, desde que o contraste seja elevado para **7:1 (WCAG AAA)** para compensar a escala e a flexibilização seja documentada no `EXCEPTIONS.md`, a mesma regra de registro que se aplica às flexibilizações por perfil (Seção 0.1).
 - **Target Spacing & Hit Area:** Ver *Seção 3 — Targets* para a regra de tamanho mínimo e exceções. Em UIs densas (ex: tabelas), se o tamanho visual for menor que 44px, a **hit area** (area de clique invisível) **MUST** ser expandida via CSS/padding. Adjacentes **SHOULD** ter 8px de espaçamento.
 
 ## 5. Complex Component Protocol


### PR DESCRIPTION
## Problem

The minimum font size is defined in two places with different conditions:

- **Section 0.1 (Compliance Profile table):** 12px for Standard (AA); 10px only under the Launchpad profile, gated on an `EXCEPTIONS.md` entry.
- **Section 4 (Typography):** flat "MUST NOT be smaller than 12px", with a *Density Exception* allowing 10px in dense dashboards gated only on 7:1 contrast.

An AI agent reading both cannot tell whether 10px under the Standard profile is allowed, and if so, under which condition (`EXCEPTIONS.md` log vs. 7:1 contrast). When two rules conflict, agents pick one arbitrarily, which defeats the deterministic intent of the contract.

## Solution

Make Section 4 derive the baseline from the active Compliance Profile (Section 0.1), and require the density exception to satisfy **both** conditions: 7:1 contrast compensation **and** an `EXCEPTIONS.md` entry, matching the logging rule the profile table already establishes.

This mirrors the cross-reference approach Section 4 already uses for target sizes ("See Section 3 — Targets"). Applied to both `docs/en/A11Y.md` and `docs/pt-BR/A11Y.md`.

Made with [Cursor](https://cursor.com)