### PR TITLE
v1.1.0 — Normative precision (WCAG SCs vs House Rules), Platform Awareness, Component Reuse & Decision Memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the A11y Guidelines project will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2026-07-20
+
+### Added
+- **Platform Awareness (AI Behavior Contract):** The AI must identify the target platform before loading any reference; on native platforms, web references are semantic intent to translate, never implementation to copy.
+- **`guide-platform-native.md`:** Translation layer mapping web semantics (roles, labels, live regions, focus, reduced motion, text scaling) to iOS (SwiftUI), Android (Compose), React Native, and Flutter.
+- **Component Reuse + Decision Memory (AI Behavior Contract):** Before generating any interactive component, the AI must reuse existing project implementations; choices between equally conformant alternatives are recorded in the new `templates/A11Y-DECISIONS.md` (pattern-indexed decision log) and reused across turns.
+- **Normative traceability:** WCAG 2.2 Success Criteria now cited by number throughout the core file and profile guide.
+
+### Changed
+- **Normative precision — WCAG requirements vs House Rules† now explicitly separated:**
+  - Target size: the AA requirement is **24×24px (SC 2.5.8)** — 44×44px (Apple HIG/Material) is now labeled a House Rule; under Shield, 44×44 is normative (SC 2.5.5 AAA) with 48×48 house-advised.
+  - Minimum font sizes (14/12/10px) and the Density Exception are now labeled House Rules — WCAG defines no minimum font size and no size-for-contrast compensation.
+  - Shield profile: corrected to 7:1 text (SC 1.4.6) with UI components at 3:1 (SC 1.4.11 — WCAG has no AAA non-text contrast criterion).
+  - Zoom: unified as text resize to 200% (SC 1.4.4) + reflow at 320 CSS px (SC 1.4.10) across core and guides (previously inconsistent 200%/400%).
+- **Reference Library:** all 21 guides are now reachable from the core file (POUR sections, §0.1 and the Reference Library) — the 10 guides added in 1.0.0 were previously unreachable via Lazy Loading.
+- **Complex Component Protocol:** step 2 now requires requesting human screen-reader validation — the AI MUST NOT claim the test was performed nor fabricate results; step 4 records resolved patterns in `A11Y-DECISIONS.md` instead of creating new reference examples.
+- **Quick Start:** the primary install flow is now a single rule in the agent's configuration pointing at this repository (or a local copy for offline/pinned use) — no file copying required.
+- **`guide-responsive-mobile.md`:** rescoped as *Responsive Web & Zoom* (browser only) and corrected per SC 1.4.4/1.4.10; native mobile now lives in `guide-platform-native.md`.
+
+### Fixed
+- **Errata:** the 1.0.0 notes claimed framework mapping for "12+ other framework syntaxes"; the guide covers React plus 5 web targets (Vue/Nuxt, Angular, Svelte, SolidJS, Vanilla/Lit).
+
 ## [1.0.0] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@
 > **A11Y.md is not a guideline.**
 > It is an accessibility validation protocol and a **persistent context architecture** for developing accessible software with AI. It is designed to integrate with AI agent systems (Cursor, Claude, Copilot) to ensure certifiable compliance from genesis.
 
-We treat `.gitignore`, `eslint`, and `CLAUDE.md` as canonical truths in our repositories. But why isn't accessibility canonical? `A11Y.md` translates accessibility rules into a universal, portable governance layer. Instead of generic coding advice, it forces any coding agent to strictly adhere to WCAG 2.2 AA and ADA standards from the very first line of generated UI code.
+We treat `.gitignore`, `eslint`, and `CLAUDE.md` as canonical truths in our repositories. But why isn't accessibility canonical? `A11Y.md` translates accessibility rules into a portable governance layer: a **platform-agnostic normative core** (POUR, compliance profiles, severity, governance) with **mature web references** and a **native translation layer** (iOS, Android, React Native, Flutter). Instead of generic coding advice, it forces any coding agent to strictly adhere to WCAG 2.2 AA and ADA standards from the very first line of generated UI code.
 
 ---
 
 ## ⚡ Core Features
 
-- 🧠 **8-Rule AI Behavioral Contract:** A strict set of deterministic constraints that force the AI to act as a semantic translator (Framework Adaptation) and stop generating dangerous anti-patterns (like "clickable divs").
-- 🛡️ **Modular Compliance Profiles:** Support for Shield (AAA), Standard (AA), and **Launchpad (A)**. The Launchpad profile allows startups to build rapid MVPs by relaxing visual constraints without ever sacrificing critical semantic structure.
-- 📚 **Lazy Context Loading:** 20 deep engineering guides (WAI-ARIA APG) that act as an actionable database. The AI is programmed to load only the guides it needs on-demand, saving tokens and maintaining sharp focus.
+- 🧠 **11-Rule AI Behavioral Contract:** A strict set of deterministic constraints that force the AI to act as a semantic translator (Framework Adaptation, Platform Awareness), reuse the project's existing components instead of recreating them (Component Reuse + Decision Memory), and stop generating dangerous anti-patterns (like "clickable divs").
+- 🛡️ **Modular Compliance Profiles:** Support for Shield (AAA), Standard (AA), and **Launchpad (A)** — each separating what WCAG actually requires (cited by Success Criterion) from this standard's stricter **House Rules**. The Launchpad profile allows startups to build rapid MVPs by relaxing visual constraints without ever sacrificing critical semantic structure.
+- 📚 **Lazy Context Loading:** 21 reference guides (WAI-ARIA APG) that act as an actionable database. The AI is programmed to load only the guides it needs on-demand, saving tokens and maintaining sharp focus.
 
 ---
 
@@ -35,9 +35,11 @@ We treat `.gitignore`, `eslint`, and `CLAUDE.md` as canonical truths in our repo
 
 Reading about accessibility is the first step, injecting it into your code is the real goal. Do this **right now** in your project:
 
-1. **Download the Standard:** Copy the `docs/en/A11Y.md` file into your application's repository. (It can be placed in the root, inside a `docs/` folder, or anywhere else). Optionally, also copy the `references/` and `templates/` folders next to it to keep the deep-dive guides available offline; if you skip them, the AI falls back to the guides in this repository via their upstream URLs.
-2. **Inject the Command:** You must explicitly instruct your AI to read it. If you use a `.cursorrules` or `CLAUDE.md` file, add this directive:
-   > *"When developing the frontend, follow strictly the development rules defined in the A11Y.md file."*
+1. **Point your AI to the Standard:** Add **one rule** to your agent's configuration file (`.cursorrules`, `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`…):
+   > *"When developing the frontend, follow strictly the accessibility rules defined in A11Y.md: https://github.com/fecarrico/A11Y.md/blob/main/docs/en/A11Y.md"*
+
+   That's it — no files copied. The AI reads the core file and lazy-loads only the reference guides it needs, always up to date. (Prefer Portuguese? Point to `docs/pt-BR/A11Y.md` instead.)
+2. **Prefer an offline or pinned copy?** Copy `docs/en/A11Y.md` into your repository (root, `docs/`, anywhere) — optionally with the `references/` and `templates/` folders — and point the rule at the local path. If you copy only the core file, the AI falls back to this repository's guides via their upstream URLs.
 3. **Set the Profile:** The AI will proactively ask you which Compliance Profile (Shield, Standard, or Launchpad) to use if you don't specify one.
 
 👉 **<a href="https://github.com/fecarrico/A11Y.md/wiki/Setup-and-Integration" target="_blank">Read the full Setup and Integration guide on our Wiki.</a>**
@@ -53,7 +55,7 @@ The complete architecture, protocols, and practical examples are thoroughly docu
 Inside, you will find:
 - **The Command Center:** How the core `A11Y.md` file works.
 - **Anti-patterns & Protocol:** Real-world examples of AI hallucinations being fixed.
-- **Reference Library:** The taxonomy of the 20 engineering guides.
+- **Reference Library:** The taxonomy of the 21 engineering guides.
 - **Governance & Compliance:** Preparing for VPATs and formal audits.
 
 ---

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Inside, you will find:
 - **The Command Center:** How the core `A11Y.md` file works.
 - **Anti-patterns & Protocol:** Real-world examples of AI hallucinations being fixed.
 - **Reference Library:** The taxonomy of the 21 engineering guides.
+- **Evidence & Research:** The field data the standard responds to — published benchmarks and studies, with sources.
 - **Governance & Compliance:** Preparing for VPATs and formal audits.
 
 ---

--- a/README.md
+++ b/README.md
@@ -3,12 +3,13 @@
 <div align="center">
   <img src="./a11ymd.png" alt="Project A11Y.md Banner" style="max-width: 100%; border-radius: 8px;" />
   <br/><br/>
-  <h1>♿ Project A11Y.md</h1>
+  <h1>Project A11Y.md</h1>
   <p><b>The Persistent Context System for Accessibility</b></p>
   
   [![WCAG 2.2 AA](https://img.shields.io/badge/WCAG-2.2_AA-blue.svg)](#)
   [![ADA Compliant](https://img.shields.io/badge/Compliance-ADA%20%7C%20EAA-success.svg)](#)
   [![AI Ready](https://img.shields.io/badge/Context-AI_Ready-purple.svg)](#)
+  [![Claude for Open Source](https://img.shields.io/badge/Anthropic-Claude_for_Open_Source-D97757.svg)](#)
   
   <br/>
   <a href="https://github.com/fecarrico/A11Y.md/wiki" target="_blank">📖 Read the Official Wiki</a> | <a href="https://v0-projecta11y.vercel.app/" target="_blank">🌐 Official Website</a> | <a href="https://open.substack.com/pub/felipearriadacarrio340730/p/a11ymd-accessibility-before-any-prompt" target="_blank">📝 Read the Manifesto (Substack)</a>
@@ -88,7 +89,9 @@ Our philosophy dictates that web accessibility should never be an "afterthought 
 
 ## 🤝 Open Source & Community
 
-A11Y.md is fundamentally an open-source initiative. Felipe does not claim to be a definitive accessibility expert, but rather a curious advocate deeply invested in the intersection of inclusion and artificial intelligence. 
+A11Y.md is fundamentally an open-source initiative. In July 2026, the project was selected for **Anthropic's Claude for Open Source** program, which supports open-source maintainers worldwide.
+
+Felipe does not claim to be a definitive accessibility expert, but rather a curious advocate deeply invested in the intersection of inclusion and artificial intelligence. 
 
 The goal of this project is to be a living, breathing architecture. It relies on the open-source community — people far smarter and more experienced in accessibility engineering — to contribute, refine the reference library, and make this system robust enough to fundamentally change how digital solutions are created in the era of "vibe coding". 
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -60,6 +60,7 @@ Lá dentro você encontrará:
 - **O Command Center:** Como o arquivo principal A11Y.md funciona.
 - **Anti-patterns & Protocol:** Casos reais de alucinações de IA sendo corrigidas nativamente.
 - **Reference Library:** A taxonomia dos 21 guias de engenharia.
+- **Evidence & Research:** Os dados de campo aos quais o padrão responde — benchmarks e estudos publicados, com fontes.
 - **Governança & Compliance:** Preparação técnica para auditorias formais.
 
 ---

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -6,12 +6,13 @@
 <div align="center">
   <img src="./a11ymd.png" alt="Project A11Y.md Banner" style="max-width: 100%; border-radius: 8px;" />
   <br/><br/>
-  <h1>♿ Project A11Y.md</h1>
+  <h1>Project A11Y.md</h1>
   <p><b>O Sistema de Contexto Persistente para Acessibilidade</b></p>
   
   [![WCAG 2.2 AA](https://img.shields.io/badge/WCAG-2.2_AA-blue.svg)](#)
   [![ADA Compliant](https://img.shields.io/badge/Compliance-ADA%20%7C%20EAA-success.svg)](#)
   [![AI Ready](https://img.shields.io/badge/Context-AI_Ready-purple.svg)](#)
+  [![Claude for Open Source](https://img.shields.io/badge/Anthropic-Claude_for_Open_Source-D97757.svg)](#)
   
   <br/>
   <a href="https://github.com/fecarrico/A11Y.md/wiki" target="_blank">📖 Leia a Wiki Oficial</a> | <a href="https://v0-projecta11y.vercel.app/" target="_blank">🌐 Site Oficial</a> | <a href="https://medium.com/ux-user-experience-design-em-portugues/a11y-md-acessibilidade-antes-de-qualquer-prompt-5c8778ccb310" target="_blank">📝 Leia o Manifesto (Medium)</a>
@@ -91,7 +92,9 @@ Nossa filosofia determina que a acessibilidade web nunca deve ser um "polimento 
 
 ## 🤝 Open Source & Comunidade
 
-O A11Y.md é fundamentalmente uma iniciativa open-source. Não me coloco como o dono da verdade absoluta em acessibilidade, mas sim como um entusiasta tentando cruzar a ponte entre Inclusão e Inteligência Artificial.
+O A11Y.md é fundamentalmente uma iniciativa open-source. Em julho de 2026, o projeto foi selecionado para o programa **Claude for Open Source, da Anthropic**, que apoia mantenedores open-source no mundo todo.
+
+Não me coloco como o dono da verdade absoluta em acessibilidade, mas sim como um entusiasta tentando cruzar a ponte entre Inclusão e Inteligência Artificial.
 
 O objetivo deste projeto é ser uma arquitetura viva. Ele depende da comunidade open-source — pessoas muito mais inteligentes e experientes em engenharia de acessibilidade — para contribuir, refinar a biblioteca de referências e tornar esse sistema robusto o suficiente para mudar como soluções digitais são criadas na era do "vibe coding".
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -22,15 +22,15 @@
 > **O A11Y.md não é um guia de boas práticas.**
 > Ele é um protocolo de validação de acessibilidade e uma **arquitetura de contexto persistente** para o desenvolvimento de softwares guiado por IA. Foi concebido para integrar-se com agentes autônomos (Cursor, Claude, Copilot) garantindo conformidade certificável desde a origem.
 
-Nós tratamos arquivos como `.gitignore`, `eslint` e `CLAUDE.md` como verdades canônicas nos nossos repositórios. Mas por que a acessibilidade não é canônica? O `A11Y.md` traduz as regras de acessibilidade para uma camada de governança universal. Em vez de regras genéricas, ele força qualquer agente a aderir estritamente às normas WCAG 2.2 AA e ADA desde a primeira linha de código gerada.
+Nós tratamos arquivos como `.gitignore`, `eslint` e `CLAUDE.md` como verdades canônicas nos nossos repositórios. Mas por que a acessibilidade não é canônica? O `A11Y.md` traduz as regras de acessibilidade para uma camada de governança portátil: um **núcleo normativo agnóstico de plataforma** (POUR, perfis de conformidade, severidade, governança) com **referências web maduras** e uma **camada de tradução nativa** (iOS, Android, React Native, Flutter). Em vez de regras genéricas, ele força qualquer agente a aderir estritamente às normas WCAG 2.2 AA e ADA desde a primeira linha de código gerada.
 
 ---
 
 ## ⚡ Core Features (Inovações)
 
-- 🧠 **Contrato Comportamental da IA (8 Regras):** Restrições determinísticas que forçam a IA a atuar como uma tradutora semântica entre frameworks e a parar de gerar anti-padrões destrutivos (como `divs` clicáveis).
-- 🛡️ **Compliance Profiles Modulares:** Suporte aos perfis Shield (AAA), Standard (AA) e **Launchpad (A)**. O perfil Launchpad permite que startups construam MVPs rápidos relaxando regras visuais cosméticas, sem nunca sacrificar a estrutura semântica crítica.
-- 📚 **Lazy Context Loading:** 20 guias profundos de engenharia (WAI-ARIA APG). A IA é programada para carregar apenas os guias necessários sob demanda, economizando tokens e mantendo o foco afiado.
+- 🧠 **Contrato Comportamental da IA (11 Regras):** Restrições determinísticas que forçam a IA a atuar como tradutora semântica (Framework Adaptation, Platform Awareness), a reutilizar os componentes existentes do projeto em vez de recriá-los (Component Reuse + Decision Memory) e a parar de gerar anti-padrões destrutivos (como `divs` clicáveis).
+- 🛡️ **Compliance Profiles Modulares:** Suporte aos perfis Shield (AAA), Standard (AA) e **Launchpad (A)** — cada um separando o que a WCAG realmente exige (citado por Critério de Sucesso) das **Regras da Casa** mais estritas deste padrão. O perfil Launchpad permite que startups construam MVPs rápidos relaxando regras visuais cosméticas, sem nunca sacrificar a estrutura semântica crítica.
+- 📚 **Lazy Context Loading:** 21 guias de referência (WAI-ARIA APG). A IA é programada para carregar apenas os guias necessários sob demanda, economizando tokens e mantendo o foco afiado.
 
 ---
 
@@ -38,9 +38,11 @@ Nós tratamos arquivos como `.gitignore`, `eslint` e `CLAUDE.md` como verdades c
 
 Ler sobre acessibilidade é o primeiro passo, injetá-la no código é o objetivo real. Faça isto **agora** no seu projeto:
 
-1. **Baixe o Padrão:** Copie o arquivo `docs/pt-BR/A11Y.md` para o repositório da sua aplicação. (Ele pode ser colocado na raiz, dentro de uma pasta `docs/`, ou em qualquer outro lugar). Opcionalmente, copie também as pastas `references/` e `templates/` junto dele para manter os guias detalhados disponíveis offline; se você não copiá-las, a IA usa como fallback os guias deste repositório via URLs upstream.
-2. **Injete o Comando:** Você precisa instruir explicitamente a sua IA a lê-lo. Se você usa um arquivo `.cursorrules` ou `CLAUDE.md`, adicione esta diretiva:
-   > *"Ao desenvolver o frontend, siga estritamente as regras de desenvolvimento definidas no arquivo A11Y.md."*
+1. **Aponte sua IA para o Padrão:** Adicione **uma regra** ao arquivo de configuração do seu agente (`.cursorrules`, `CLAUDE.md`, `AGENTS.md`, `copilot-instructions.md`…):
+   > *"Ao desenvolver o frontend, siga estritamente as regras de acessibilidade definidas no A11Y.md: https://github.com/fecarrico/A11Y.md/blob/main/docs/pt-BR/A11Y.md"*
+
+   Só isso — nenhum arquivo copiado. A IA lê o arquivo núcleo e carrega sob demanda apenas os guias de referência necessários, sempre atualizados. (Prefere inglês? Aponte para `docs/en/A11Y.md`.)
+2. **Prefere uma cópia offline ou fixada?** Copie o `docs/pt-BR/A11Y.md` para o seu repositório (raiz, `docs/`, onde quiser) — opcionalmente com as pastas `references/` e `templates/` — e aponte a regra para o caminho local. Se copiar só o arquivo núcleo, a IA usa como fallback os guias deste repositório via URLs upstream.
 3. **Defina o Perfil:** A IA perguntará proativamente qual Compliance Profile (Shield, Standard ou Launchpad) ela deve usar, caso você não tenha especificado.
 
 👉 **<a href="https://github.com/fecarrico/A11Y.md/wiki/Setup-and-Integration" target="_blank">Leia o guia completo de Setup e Integração na nossa Wiki.</a>**
@@ -56,7 +58,7 @@ A arquitetura completa, protocolos e exemplos práticos estão profundamente doc
 Lá dentro você encontrará:
 - **O Command Center:** Como o arquivo principal A11Y.md funciona.
 - **Anti-patterns & Protocol:** Casos reais de alucinações de IA sendo corrigidas nativamente.
-- **Reference Library:** A taxonomia dos 20 guias de engenharia.
+- **Reference Library:** A taxonomia dos 21 guias de engenharia.
 - **Governança & Compliance:** Preparação técnica para auditorias formais.
 
 ---

--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -1,5 +1,5 @@
 # A11y Guidelines: Accessibility as a Baseline
-> **Version:** 1.0.0 | **Target Standard:** WCAG 2.2 AA | **Last Updated:** 2026-07-03
+> **Version:** 1.1.0 | **Target Standard:** WCAG 2.2 AA | **Last Updated:** 2026-07-20
 
 This document establishes the persistent context required so that the software **can be certified** under the **WCAG 2.2 AA**, **ISO 9241-171**, **ADA**, and **EAA** standards, depending on rigorous implementation and **mandatory human validation**.
 
@@ -14,13 +14,15 @@ This document establishes the persistent context required so that the software *
 This document defaults to **Standard (AA)** compliance.
 When generating or reviewing interface code, the AI should ask the user which compliance profile to apply if not already specified:
 
-| Profile | Target | Contrast | Min Font | Targets | Use Case |
+| Profile | Target | Contrast (text / UI) | Min Font† | Min Target | Use Case |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **🛡️ Shield (AAA)** | WCAG AAA | 7:1 text, 4.5:1 UI | 14px | 48×48px | Regulated industries, healthcare, gov |
-| **⚖️ Standard (AA)** | WCAG AA | 4.5:1 text, 3:1 UI | 12px | 44×44px | Default. Production apps, public web |
-| **🚀 Launchpad (A)** | WCAG A | 3:1 text (minimum) | 10px* | 24×24px* | MVPs, internal tools, prototypes |
+| **🛡️ Shield (AAA)** | WCAG AAA | 7:1 / 3:1 (SC 1.4.6, 1.4.11) | 14px† | 44×44px (SC 2.5.5) · 48×48px† advised | Regulated industries, healthcare, gov |
+| **⚖️ Standard (AA)** | WCAG AA | 4.5:1 / 3:1 (SC 1.4.3, 1.4.11) | 12px† | 24×24px (SC 2.5.8) · 44×44px† advised | Default. Production apps, public web |
+| **🚀 Launchpad (A)** | WCAG A | 3:1† (house floor) | 10px† | 24×24px† | MVPs, internal tools, prototypes |
 
-*Launchpad profile requires explicit EXCEPTIONS.md documentation for each relaxed criterion.*
+*† = **House Rule**, non-normative: this standard's ergonomic policy where WCAG requires less — or nothing — at that level. WCAG defines no minimum font size at any level; Level A defines no contrast or target-size criteria; 44–48px targets come from Apple HIG / Material Design. Skipping a **WCAG SC** at your target level MUST be logged in `EXCEPTIONS.md`; relaxing a **House Rule** is a product decision — record it in `A11Y-DECISIONS.md`.*
+
+*Launchpad additionally requires explicit `EXCEPTIONS.md` documentation for each criterion relaxed below AA.*
 
 > ⚠️ The **Launchpad (A)** profile does NOT relax CRITICAL rules (Section 1). 
 > Keyboard operability, focus management, and semantic HTML remain mandatory 
@@ -41,54 +43,54 @@ To ensure technical integrity, any AI interacting with this repository **MUST**:
 - **Protocol for Ambiguity:** Follow the *Complex Component Protocol* in case of uncertainty.
 - **Explain Trade-offs:** Explain impacts on Accessibility vs UX vs Business when suggesting changes.
 - **UI Component Interrogation:** Before adding `onClick` to non-semantic elements, the AI **MUST** propose replacing them with native elements or full ARIA patterns.
-- **Framework Adaptation:** Examples in this document use React/TSX syntax. The AI MUST transpose patterns to the active project's framework while preserving semantic equivalence. *Reference: [Framework Mapping](references/guide-framework-mapping.md)*
+- **Framework Adaptation:** Examples in this document use React/TSX syntax. On **web** frameworks, the AI MUST transpose patterns to the active project's framework while preserving semantic equivalence. *Reference: [Framework Mapping](references/guide-framework-mapping.md)*
+- **Platform Awareness:** The AI MUST identify the target platform **before** loading any reference. The normative layer of this document (Principle Zero, POUR, profiles, severity, governance) is platform-agnostic; the technical references are web-first. On native platforms (iOS, Android, React Native, Flutter), web references MUST be read as **semantic intent to translate — never implementation to copy**: no ARIA attributes or CSS pixels outside the web. *Reference: [Platform-Native Mapping](references/guide-platform-native.md)*
+- **Component Reuse:** Before generating any interactive component, the AI MUST check for an existing implementation in the project or its design system and extend it. Generating a parallel implementation of an existing pattern is a violation.
+- **Decision Memory:** Choices between equally conformant alternatives (e.g., `alertdialog` vs `dialog` for a destructive confirmation) MUST be recorded in `A11Y-DECISIONS.md` — indexed by pattern, never by screen — and reused in later turns. *Reference: [Decisions Log](templates/A11Y-DECISIONS.md)*
 - **Mode Awareness:** When generating new code, apply all rules proactively. When reviewing existing code, identify violations, classify by severity (Section 1), and suggest targeted fixes — do not propose full rewrites unless the structural damage is CRITICAL.
 
 ## 3. Technical Standards (POUR Framework)
 
 ### Perceivable
-*References: [Images](references/guide-images.md) | [Content & Timing](references/guide-content-interaction.md) | [Visual Perception & Color](references/guide-visual-perception.md)*
-- **Contrast:** Text **MUST** have 4.5:1; UI Elements **MUST** have 3:1. Prioritize real **luminance difference** (light vs dark) beyond hue.
-- **Alt Text:** Informative images **MUST** have a functional description in `alt`.
+*References: [Images](references/guide-images.md) | [Content & Timing](references/guide-content-interaction.md) | [Visual Perception & Color](references/guide-visual-perception.md) | [Responsive & Zoom](references/guide-responsive-mobile.md)*
+- **Contrast (SC 1.4.3, 1.4.11):** Text **MUST** have 4.5:1; UI components and meaningful graphics **MUST** have 3:1. Prioritize real **luminance difference** (light vs dark) beyond hue.
+- **Alt Text (SC 1.1.1):** Informative images **MUST** have a functional description in `alt`.
 - **Semantic Redundancy:** **MUST NOT** convey state using color alone. The use of **Icon + Text + Color** (e.g., 🔴 Error) is the mandatory standard.
 - **Visual Patterns:** Charts and dashboards **MUST** use textures or distinct line styles to ensure differentiation without color.
 
 ### Operable
-*References: [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md)*
-- **Keyboard:** 100% of functionalities **MUST** be operable without a mouse. Avoid purely pointer-based listeners without keyboard event equivalents (`onKeyDown`).
-- **Focus:** Focus **MUST** be visible, persistent, and never suppressed via CSS (`outline: none` without fallback is forbidden).
+*References: [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md) | [Tabs & Accordions](references/guide-tabs-accordion.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Drag & Drop](references/guide-drag-drop.md) | [Autocomplete](references/guide-autocomplete.md) | [Infinite Scroll](references/guide-infinite-scroll.md)*
+- **Keyboard (SC 2.1.1):** 100% of functionalities **MUST** be operable without a mouse. Avoid purely pointer-based listeners without keyboard event equivalents (`onKeyDown`).
+- **Focus (SC 2.4.7, 2.4.11):** Focus **MUST** be visible, never entirely obscured by author content (e.g., sticky headers/footers), persistent, and never suppressed via CSS (`outline: none` without fallback is forbidden).
 - **SPA Routing (Single Page Applications):** After client-side routing changes, focus **MUST** be managed and properly reset (e.g., sending focus to the top or an H1). Avoid lost focus on the screen.
-- **Targets:** Interactive elements MUST have a minimum size of **44x44 CSS pixels**.
-
-  Smaller targets (e.g. 24x24) are only acceptable when:
-  - equivalent larger targets exist, or
-  - sufficient spacing prevents accidental activation
-- **Motion:** **MUST** respect the CSS media query `@media (prefers-reduced-motion)`. Avoid heavy state animations during crucial transitions if the preference is active.
+- **Targets (SC 2.5.8):** Interactive elements MUST have a minimum size of **24x24 CSS pixels** — the WCAG 2.2 AA floor — except when an equivalent larger target exists, sufficient spacing prevents accidental activation, or the target sits inline in text.
+  **House Rule†:** design to **44x44px** (48×48 under Shield), the ergonomic floor shared by Apple HIG and Material Design. Under Shield, 44×44 is normative (SC 2.5.5 AAA).
+- **Motion (SC 2.3.3 AAA — enforced as House Rule† at every profile):** **MUST** respect the CSS media query `@media (prefers-reduced-motion)`. Avoid heavy state animations during crucial transitions if the preference is active.
 
 ### Understandable
-*References: [Forms & Errors](references/guide-forms.md) | [Content & Microcopy](references/guide-content-interaction.md)*
-- **Labels:** Forms **MUST** have explicit labels connected via `id` and `for`, or via tag wrapping. Avoid reinventions that break native browser events.
+*References: [Forms & Errors](references/guide-forms.md) | [Content & Microcopy](references/guide-content-interaction.md) | [Tables](references/guide-tables.md) | [Toasts & Notifications](references/guide-toasts-notifications.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Tooltips & Popovers](references/guide-tooltips-popovers.md)*
+- **Labels (SC 1.3.1, 3.3.2):** Forms **MUST** have explicit labels connected via `id` and `for`, or via tag wrapping. Avoid reinventions that break native browser events.
 - **Predictability:** Navigation behavior **MUST** be consistent and interactions must not cause unannounced sudden structural changes.
-- **Dynamic Feedback:** Dynamic events based on component state (such as Toasts, loading, and AJAX/fetch form successes) **MUST** be actively read or informed through `aria-live` regions or modern equivalents (`role="status"`, `role="alert"`).
+- **Dynamic Feedback (SC 4.1.3):** Dynamic events based on component state (such as Toasts, loading, and AJAX/fetch form successes) **MUST** be actively read or informed through `aria-live` regions or modern equivalents (`role="status"`, `role="alert"`).
 
 ### Robust
-*References: [Governance & Compliance](references/guide-governance.md)*
+*References: [Governance & Compliance](references/guide-governance.md) | [Framework Mapping](references/guide-framework-mapping.md) | [Platform-Native Mapping](references/guide-platform-native.md)*
 - **Semantic HTML:** **MUST** prefer native (HTML5) elements over custom ones.
 - **Interoperability:** The code **MUST** be compatible with current assistive technologies (ISO 9241-171).
 
 ## 4. Visual Directives (Strict UI Criteria)
 To ensure certification, these visual guidelines are non-negotiable:
-- **Focus Indicator:** The focus ring **MUST** have a minimum thickness of 2px and a contrast of at least 3:1 against the background.
-- **Typography:** Text **MUST NOT** be smaller than the minimum font size of the active Compliance Profile (Section 0.1); 12px under the default Standard (AA).
-    - *Density Exception:* In complex dashboards or secondary metadata (badges), **min 10px** is allowed, provided the contrast is raised to **7:1 (WCAG AAA)** to compensate for the scale and the relaxation is documented in `EXCEPTIONS.md`, the same logging rule that applies to profile-level relaxations (Section 0.1).
+- **Focus Indicator (House Rule† — inspired by SC 2.4.13 AAA, whose normative metric is an indicator area ≥ a 2 CSS px perimeter with 3:1 contrast between the focused/unfocused states):** The focus ring **MUST** have a minimum thickness of 2px and a contrast of at least 3:1 against the background. (The AA floor: focus visible — SC 2.4.7 — and not entirely obscured by author content — SC 2.4.11.)
+- **Typography (House Rule† — WCAG defines no minimum font size at any level):** Text **MUST NOT** be smaller than the minimum font size of the active Compliance Profile (Section 0.1); 12px under the default Standard (AA).
+    - *Density Exception:* In complex dashboards or secondary metadata (badges), **min 10px** is allowed, provided the contrast is raised to **7:1** as mitigation — a trade-off defined by this standard's policy, not by WCAG, which has no size-for-contrast compensation mechanism — and the relaxation is documented in `EXCEPTIONS.md`, the same logging rule that applies to profile-level relaxations (Section 0.1).
 - **Target Spacing & Hit Area:** See *Section 3 — Targets* for the minimum size rule and exceptions. In dense UIs (e.g., tables), if the visual size is smaller than 44px, the **hit area** (invisible clickable area) **MUST** be expanded via CSS/padding. Adjacent targets **SHOULD** have 8px of spacing.
 
 ## 5. Complex Component Protocol
 When identifying an unmapped or highly complex component (e.g., Charts, Dynamic Grids):
 1. **Identify:** Look for a similar pattern in the [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/).
-2. **Validate:** Test prototype with a Screen Reader.
+2. **Validate:** Request human validation with a screen reader — the AI **MUST NOT** claim this test was performed, nor fabricate its results.
 3. **Document:** Document expected behavior (keyboard and announcements).
-4. **Scale:** Create a reusable example in the `references/` folder.
+4. **Scale:** Record the resolved pattern in `A11Y-DECISIONS.md` so future components reuse it instead of re-deriving it.
 
 ## 6. Anti-patterns (Do NOT do this)
 - **Clickable Divs:** **MUST NOT** use `div` or `span` for click actions. Prefer native buttons. If forced to use them, manually replicate the behavior of a `<button>` (`role`, `tabindex="0"`, Enter and Space event listeners).
@@ -108,13 +110,13 @@ When identifying an unmapped or highly complex component (e.g., Charts, Dynamic 
 - [ ] **Technical Check:** Clean code, testable via integrated linter (`eslint-plugin-jsx-a11y` or similar), and passing without critical violations through engines like `Axe`.
 - [ ] **Tab Order:** `Tab` key path manually validated (Ensures absence of frontend dead-ends).
 - [ ] **User Flow:** Dynamic interactions (SPAs) tested for feedback via `aria-live` in error and success scenarios without mouse use.
-- [ ] **Zoom:** UI flexibility preserved using relative density (Rem/Em), adaptable up to 400% zoom.
+- [ ] **Zoom & Reflow:** Text resizes up to 200% without loss of content or function (SC 1.4.4); content reflows at 320 CSS px width — equivalent to 400% zoom on a 1280px viewport — without two-dimensional scrolling (SC 1.4.10). Preserve flexibility using relative density (Rem/Em).
 - [ ] **Color & Perception:** No functional loss when losing the exclusive use of colors (vision deficiency simulators).
 
 ---
 ### 📚 Reference & Templates Library
-**Technical Guides:** [Images](references/guide-images.md) | [Forms](references/guide-forms.md) | [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md) | [Content](references/guide-content-interaction.md) | [Visual Perception](references/guide-visual-perception.md) | [Governance](references/guide-governance.md)
+**Technical Guides:** [Images](references/guide-images.md) | [Forms](references/guide-forms.md) | [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md) | [Content](references/guide-content-interaction.md) | [Visual Perception](references/guide-visual-perception.md) | [Tables](references/guide-tables.md) | [Tabs & Accordions](references/guide-tabs-accordion.md) | [Tooltips & Popovers](references/guide-tooltips-popovers.md) | [Toasts & Notifications](references/guide-toasts-notifications.md) | [Autocomplete](references/guide-autocomplete.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Drag & Drop](references/guide-drag-drop.md) | [Infinite Scroll](references/guide-infinite-scroll.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Responsive & Zoom](references/guide-responsive-mobile.md) | [Framework Mapping](references/guide-framework-mapping.md) | [Platform-Native Mapping](references/guide-platform-native.md) | [Compliance Profiles](references/guide-compliance-profiles.md) | [Governance](references/guide-governance.md)
 
 **External Standards:** [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/) | [eBay MIND Patterns](https://ebay.github.io/mindpatterns/) | [Deque Axe Core](https://github.com/dequelabs/axe-core)
 
-**Optional Templates:** [Accessibility Report](templates/REPORT.md) | [Exceptions Log](templates/EXCEPTIONS.md)
+**Optional Templates:** [Accessibility Report](templates/REPORT.md) | [Exceptions Log](templates/EXCEPTIONS.md) | [Decisions Log](templates/A11Y-DECISIONS.md)

--- a/docs/en/SETUP.md
+++ b/docs/en/SETUP.md
@@ -4,6 +4,8 @@ This guide explains how to properly configure your AI assistant (Cursor, Claude 
 
 > [!IMPORTANT]  
 > **Rule of Thumb:** Your environment setup file should **ONLY** contain a reference pointing to `A11Y.md`. **NEVER** copy or duplicate accessibility rules outside of `A11Y.md` — this prevents rule fragmentation and ensures the AI always loads the complete context.
+>
+> The reference can point to **this repository's URL** (always up to date, zero files copied — the recommended default) or to a **local copy** (offline/pinned). Portuguese speakers can point to `docs/pt-BR/A11Y.md`.
 
 ## Quick Reference
 
@@ -26,7 +28,7 @@ Create a `.mdc` file inside the `.cursor/rules/` directory.
 description: "Persistent accessibility context — delegates all rules to A11Y.md"
 alwaysApply: true
 ---
-Follow strictly the accessibility rules defined in the file <insert the path to your A11Y.md file here>.
+Follow strictly the accessibility rules defined in the file <path or URL to your A11Y.md — e.g. https://github.com/fecarrico/A11Y.md/blob/main/docs/en/A11Y.md, or a local copy>.
 ```
 > [!NOTE]  
 > `alwaysApply: true` is crucial. Accessibility is a strict precondition for all UI code and must not rely on glob patterns to be activated.
@@ -37,7 +39,7 @@ Add a section to your root `CLAUDE.md` file.
 **File:** `CLAUDE.md`
 ```markdown
 ## Accessibility
-Follow strictly the accessibility rules defined in the file <insert the path to your A11Y.md file here>.
+Follow strictly the accessibility rules defined in the file <path or URL to your A11Y.md — e.g. https://github.com/fecarrico/A11Y.md/blob/main/docs/en/A11Y.md, or a local copy>.
 ```
 
 ## 3. GitHub Copilot
@@ -46,7 +48,7 @@ Add the instruction to Copilot's custom instructions file.
 **File:** `.github/copilot-instructions.md`
 ```markdown
 ## Accessibility
-Follow strictly the accessibility rules defined in the file <insert the path to your A11Y.md file here>.
+Follow strictly the accessibility rules defined in the file <path or URL to your A11Y.md — e.g. https://github.com/fecarrico/A11Y.md/blob/main/docs/en/A11Y.md, or a local copy>.
 ```
 
 ## 4. Gemini / Antigravity
@@ -54,7 +56,7 @@ Add the instruction to the agent rules file.
 
 **File:** `AGENTS.md` or `.agents/AGENTS.md`
 ```markdown
-Follow strictly the accessibility rules defined in the file <insert the path to your A11Y.md file here>.
+Follow strictly the accessibility rules defined in the file <path or URL to your A11Y.md — e.g. https://github.com/fecarrico/A11Y.md/blob/main/docs/en/A11Y.md, or a local copy>.
 ```
 
 ## 5. Windsurf
@@ -62,5 +64,5 @@ Create a rule file in the Windsurf rules directory.
 
 **File:** `.windsurf/rules/a11y.md`
 ```markdown
-Follow strictly the accessibility rules defined in the file <insert the path to your A11Y.md file here>.
+Follow strictly the accessibility rules defined in the file <path or URL to your A11Y.md — e.g. https://github.com/fecarrico/A11Y.md/blob/main/docs/en/A11Y.md, or a local copy>.
 ```

--- a/docs/en/references/guide-buttons.md
+++ b/docs/en/references/guide-buttons.md
@@ -37,4 +37,4 @@
 
 ## Accessibility Implications
 - **Affordance:** Visually distinctive buttons help users with cognitive impairments identify interaction points.
-- **Precision:** Large tap targets (min 44x44px) are essential for mobile users and those with motor impairments.
+- **Precision:** Design tap targets to **44x44px** (House Rule — Apple HIG/Material; the WCAG AA floor is 24×24, SC 2.5.8): essential for mobile users and those with motor impairments.

--- a/docs/en/references/guide-compliance-profiles.md
+++ b/docs/en/references/guide-compliance-profiles.md
@@ -6,6 +6,9 @@ Accessibility is not a monolith. While **WCAG 2.2 AA** is the industry and legal
 
 This guide details the three compliance profiles supported by the `A11Y.md` ruleset.
 
+> [!NOTE]
+> **Normative vs House Rules.** Each profile mixes two layers: **WCAG Success Criteria** at its target level (cited by SC number — skipping one requires `EXCEPTIONS.md`) and **House Rules†** — this standard's stricter ergonomic policy (marked †; relaxing one is a product decision, recorded in `A11Y-DECISIONS.md`). WCAG defines **no minimum font size** at any level, and Level A defines **no contrast or target-size criteria** — every value in those positions below is a House Rule.
+
 ---
 
 ## The Profiles
@@ -25,10 +28,10 @@ This guide details the three compliance profiles supported by the `A11Y.md` rule
 **AI Instruction:** `"Apply Shield Profile (AAA)"`
 
 ### Key Requirements (Beyond AA)
-- **Contrast:** Text must have a **7:1** ratio against its background. Large text (18pt+) must have **4.5:1**.
+- **Contrast (SC 1.4.6):** Text must have a **7:1** ratio against its background. Large text (18pt+) must have **4.5:1**. UI components remain at 3:1 (SC 1.4.11 — WCAG has no AAA non-text contrast criterion).
 - **No Exceptions for Density:** Even tiny badges or labels must meet the 7:1 ratio.
-- **Targets:** All clickable elements must be at least **48×48px**. No exceptions.
-- **Focus:** The focus indicator must be highly visible (e.g., solid 2px outline with high contrast) and not rely on default browser styles.
+- **Targets (SC 2.5.5):** Clickable elements must be at least **44×44px** — the AAA minimum, with the SC's own exceptions (equivalent control, inline-in-text target, user-agent control, essential presentation). **House Rule†:** design to **48×48px** (Material norm) and allow no density exceptions under Shield.
+- **Focus (SC 2.4.13 + House Rule†):** The focus indicator must be highly visible — solid 2px outline with 3:1 contrast against the background (House Rule; the SC's normative 3:1 is measured between the focused/unfocused states) — and not rely on default browser styles.
 - **Timeouts:** Users must be able to complete tasks without arbitrary time limits, or have mechanisms to easily extend sessions.
 
 ---
@@ -40,11 +43,11 @@ This guide details the three compliance profiles supported by the `A11Y.md` rule
 **AI Instruction:** `"Apply Standard Profile (AA)"`
 
 ### Key Requirements
-- **Contrast:** Text must have a **4.5:1** ratio. Large text must have **3:1**. UI elements (borders, icons) must have **3:1**.
-- **Targets:** Clickable elements must be at least **44×44px**. Exceptions exist for inline links or when spacing prevents misclicks.
-- **Focus:** Focus must be clearly visible.
+- **Contrast (SC 1.4.3, 1.4.11):** Text must have a **4.5:1** ratio. Large text must have **3:1**. UI elements (borders, icons) must have **3:1**.
+- **Targets (SC 2.5.8):** Clickable elements must be at least **24×24px** — the AA normative floor, with exceptions for inline links and spaced targets. **House Rule†:** design to **44×44px** (Apple HIG / Material norm).
+- **Focus (SC 2.4.7):** Focus must be clearly visible.
 - **Semantic HTML & ARIA:** Strict adherence to APG patterns for complex components.
-- **Responsiveness:** Must support zooming up to 200% without loss of content or function.
+- **Responsiveness (SC 1.4.4, 1.4.10):** Text must resize to 200% without loss of content or function, and content must reflow at 320 CSS px width (≈400% zoom) without two-dimensional scrolling.
 
 ---
 
@@ -58,9 +61,9 @@ This guide details the three compliance profiles supported by the `A11Y.md` rule
 > The Launchpad profile does **NOT** mean "no accessibility". It still requires semantic HTML, keyboard operability, and screen reader support. It only relaxes strict visual criteria.
 
 ### Relaxed Criteria (Compared to AA)
-- **Contrast:** Only a baseline **3:1** ratio is enforced to prevent complete illegibility.
-- **Targets:** Target sizes can be reduced to **24×24px**, provided there is some spacing.
-- **Typography:** Fonts down to **10px** are tolerated without strict AAA contrast compensation, though highly discouraged.
+- **Contrast (House Rule†):** Only a baseline **3:1** ratio is enforced to prevent complete illegibility. (Level A has no contrast criterion — this floor is this standard's policy, not WCAG.)
+- **Targets (House Rule†):** Target sizes can be reduced to **24×24px**, provided there is some spacing. (Level A has no target-size criterion; 24×24 mirrors the AA floor of SC 2.5.8.)
+- **Typography (House Rule†):** Fonts down to **10px** are tolerated without strict contrast mitigation, though highly discouraged. (WCAG defines no minimum font size.)
 
 ### Immutable Rules (Never Relaxed)
 - ❌ `div` or `span` with `onClick` (Keyboard trap/unreachable)

--- a/docs/en/references/guide-framework-mapping.md
+++ b/docs/en/references/guide-framework-mapping.md
@@ -6,6 +6,9 @@ The `A11Y.md` standard uses **React/TSX** syntax for its examples due to its ubi
 
 When an AI agent generates or reviews code, it **MUST transpose** these patterns into the active framework of the project while preserving semantic equivalence.
 
+> [!IMPORTANT]
+> **Scope: web frameworks only.** ARIA attributes and DOM events do not exist on native platforms. For iOS, Android, React Native, or Flutter targets, use the [Platform-Native Mapping](guide-platform-native.md) guide instead — transposing ARIA to native code is a violation of the *Platform Awareness* contract rule.
+
 ## Core Translation Rules
 
 1. **Native over Custom:** Always prefer the framework's native implementation of a semantic element over building one from scratch.

--- a/docs/en/references/guide-platform-native.md
+++ b/docs/en/references/guide-platform-native.md
@@ -1,0 +1,35 @@
+# Platform-Native Accessibility Mapping
+
+> **Target Standard:** Semantic Equivalence | **Scope:** iOS (SwiftUI/UIKit), Android (Compose/Views), React Native, Flutter
+
+The normative layer of `A11Y.md` (Principle Zero, POUR, Compliance Profiles, Severity, Governance) is platform-agnostic — WCAG 2.2 is written to be technology-neutral, and [WCAG2ICT](https://www.w3.org/TR/wcag2ict-22/) maps it to non-web software. The **technical references**, however, are web-first. This guide is the translation layer.
+
+## Core Rules
+
+1. **Never emit web idioms on native platforms.** ARIA attributes, roles, and CSS pixels do not exist in SwiftUI, Compose, React Native or Flutter. Translate the *intent*, not the syntax. Inventing hybrids (e.g., `aria-live` in SwiftUI) is a 🔴 CRITICAL violation.
+2. **Prefer native components.** Platform-standard controls (Button, Switch, Alert) ship with semantics, focus behavior, and touch targets already compliant — the native equivalent of "prefer semantic HTML".
+3. **Touch targets:** **44×44pt (iOS HIG)** / **48×48dp (Material)** are the platform norms and satisfy this standard's House Rule by default. The WCAG floor (SC 2.5.8, 24×24) still applies to custom-drawn controls.
+4. **Respect system accessibility settings:** font scaling (Dynamic Type / `sp` units / `textScaler`), Reduce Motion, and increased-contrast modes are the native equivalents of zoom, `prefers-reduced-motion`, and contrast requirements.
+5. **Announce dynamic changes.** Toasts, async results, and validation errors MUST be announced through the platform's accessibility notification API — the native equivalent of `aria-live`.
+
+## Translation Table (semantic intent → platform)
+
+| Web intent | iOS (SwiftUI) | Android (Compose) | React Native | Flutter |
+| :--- | :--- | :--- | :--- | :--- |
+| `<button>` / `role="button"` | `Button` or `.accessibilityAddTraits(.isButton)` | `Button` or `Modifier.semantics { role = Role.Button }` | `accessibilityRole="button"` | `ElevatedButton` or `Semantics(button: true)` |
+| Accessible name (`aria-label`, `alt`) | `.accessibilityLabel("…")` | `contentDescription` / `semantics { contentDescription = "…" }` | `accessibilityLabel` | `Semantics(label: "…")` |
+| `aria-live` / `role="status"` | `AccessibilityNotification.Announcement("…").post()` (iOS 17+; earlier: `UIAccessibility.post(notification: .announcement, …)`) | `Modifier.semantics { liveRegion = LiveRegionMode.Polite }` (`announceForAccessibility` is deprecated in API 36) | `accessibilityLiveRegion` (Android) / `AccessibilityInfo.announceForAccessibility(…)` | `SemanticsService.sendAnnouncement(…)` — prefer live-region semantics on Android |
+| Modal dialog + focus containment | `.accessibilityAddTraits(.isModal)` (UIKit: `accessibilityViewIsModal`) | `Dialog()` (scopes focus by default) | `accessibilityViewIsModal` (iOS); hide background with `importantForAccessibility="no-hide-descendants"` (Android) | `showDialog` (route scoping); `Semantics(scopesRoute: true)` for custom overlays |
+| Heading (`<h1>`–`<h6>`) | `.accessibilityAddTraits(.isHeader)` | `Modifier.semantics { heading() }` | `accessibilityRole="header"` | `Semantics(header: true)` |
+| Disabled state (`disabled`, `aria-disabled`) | `.disabled(true)` (exposed automatically) | `enabled = false` | `accessibilityState={{disabled: true}}` | `Semantics(enabled: false)` or disabled widget |
+| Grouping related content (label + value) | `.accessibilityElement(children: .combine)` | `Modifier.semantics(mergeDescendants = true) {}` | `accessible={true}` on the container | `MergeSemantics` |
+| Focus management after navigation | `@AccessibilityFocusState` | `FocusRequester.requestFocus()` | `AccessibilityInfo.sendAccessibilityEvent(handle, 'focus')` | `FocusNode.requestFocus()` |
+| `prefers-reduced-motion` | `accessibilityReduceMotion` environment / `UIAccessibility.isReduceMotionEnabled` | Respect system animator scale; avoid gratuitous auto-animation | `AccessibilityInfo.isReduceMotionEnabled()` | `MediaQuery.of(context).disableAnimations` |
+| Text zoom (SC 1.4.4 equivalence) | Dynamic Type — use system text styles, never fixed sizes | `sp` units for text, never `dp` | `allowFontScaling` (default `true` — MUST NOT disable) | `MediaQuery` `textScaler` — never hardcode `textScaleFactor: 1.0` |
+
+## Verification (native equivalent of Section 7)
+
+- [ ] **Screen reader pass requested:** VoiceOver (iOS) / TalkBack (Android) — human validation; the AI MUST NOT claim it ran these.
+- [ ] **Font scaling:** UI survives the largest system font size without truncation or overlap.
+- [ ] **Focus/swipe order:** sequential navigation follows the visual/logical order.
+- [ ] **Announcements:** async feedback audible without touching the screen.

--- a/docs/en/references/guide-responsive-mobile.md
+++ b/docs/en/references/guide-responsive-mobile.md
@@ -1,9 +1,12 @@
-# Responsive & Mobile A11y Guide
+# Responsive Web & Zoom A11y Guide
 
-> **Scope:** Layout & Touch
+> **Scope:** Web layout, browser zoom & touch. For **native** mobile apps (iOS, Android, React Native, Flutter), see [Platform-Native Mapping](guide-platform-native.md) — this guide covers the browser only.
 
 ## Core Rules
-1. **Zoom:** UI MUST NOT break or overlap up to 200% browser zoom.
-2. **Orientation:** MUST NOT lock orientation to landscape or portrait.
-3. **Touch Targets:** Minimum 44x44 CSS pixels for touch areas on mobile devices.
-4. **Gestures:** Complex gestures (swipes) MUST have simple click equivalents.
+1. **Text Resize (SC 1.4.4):** UI MUST NOT break, clip, or lose function up to **200% text zoom**.
+2. **Reflow (SC 1.4.10):** Content MUST reflow at **320 CSS px width** (equivalent to 400% zoom on a 1280px viewport) without two-dimensional scrolling — except content that requires 2D layout (data tables, maps, charts).
+3. **Orientation (SC 1.3.4):** MUST NOT lock orientation to landscape or portrait unless essential.
+4. **Touch Targets (SC 2.5.8 + House Rule†):** 24×24 CSS px is the normative AA floor; design to **44×44px** on touch surfaces (Apple HIG / Material norm).
+5. **Gestures (SC 2.5.1):** Complex gestures (swipes, multipoint) MUST have simple single-pointer equivalents.
+
+*† = House Rule: this standard's ergonomic policy beyond the WCAG floor — see `A11Y.md` §0.1.*

--- a/docs/en/templates/A11Y-DECISIONS.md
+++ b/docs/en/templates/A11Y-DECISIONS.md
@@ -1,0 +1,18 @@
+# A11Y Decisions Log (Pattern Memory)
+
+> **Purpose:** cross-turn memory of choices between **equally conformant alternatives**. Two implementations can both pass `A11Y.md` and axe and still diverge (different `role`, focus pattern, announcement wording) — twenty compliant modals, zero coherence. This file prevents that.
+
+## Rules for the AI
+
+1. **Record only what is not derivable** from `A11Y.md` rules or from the code itself. Landmarks, headings, and alt presence are machine-verifiable — they do **NOT** belong here.
+2. **Index by pattern, never by screen.** ✅ *"Destructive confirmation modal → `alertdialog`"* · ❌ *"The dispute modal does X"*.
+3. **One line per decision:** pattern → choice → short why.
+4. **Read before building:** before generating any interactive component, check this log and reuse the recorded pattern (see *Component Reuse* in the AI Behavior Contract).
+5. **Never fork silently:** if a new requirement contradicts a recorded decision, ask the user — do not create a parallel variant.
+6. **Stay lean:** tens of lines, not hundreds. This file shares the context budget with Lazy Loading; if it grows past ~40 entries, consolidate.
+
+## Decisions
+
+<!-- Append entries below. Format: - **Pattern** → choice — why. (date) -->
+
+- **Destructive confirmation modal** → `role="alertdialog"`, initial focus on the non-destructive button, focus returns to the trigger — interruption semantics per APG. *(example — replace with your project's first real decision)*

--- a/docs/en/templates/REPORT.md
+++ b/docs/en/templates/REPORT.md
@@ -31,7 +31,7 @@ Critical functional paths and Screen Reader validation.
 Tests validating contrast and visual structure (color-independent).
 - [ ] **Text & UI Contrast:** Do all texts have a 4.5:1 ratio and essential components 3:1?
 - [ ] **Redundancy:** Errors and alerts do not convey information exclusively through color *(e.g., they always use Color + Icon + Text)*.
-- [ ] **Scale / Zoom:** When zooming in by 400%, does everything remain operable without blockages (screen overrides)?
+- [ ] **Scale / Zoom:** Text resized to 200% without loss (SC 1.4.4) and content reflowed at 320 CSS px — ≈400% zoom on a 1280px viewport (SC 1.4.10) — with everything operable and no two-dimensional scrolling?
 
 ---
 ## 📝 Assessment Notes or Known Blockers

--- a/docs/pt-BR/A11Y.md
+++ b/docs/pt-BR/A11Y.md
@@ -1,5 +1,5 @@
 # A11y Guidelines: Accessibility as a Baseline
-> **Versão:** 1.0.0 | **Padrão Alvo:** WCAG 2.2 AA | **Última Atualização:** 2026-07-03
+> **Versão:** 1.1.0 | **Padrão Alvo:** WCAG 2.2 AA | **Última Atualização:** 2026-07-20
 
 Este documento estabelece o contexto persistente necessário para que o software **possa ser certificado** segundo as normas **WCAG 2.2 AA**, **ISO 9241-171**, **ADA** e **EAA**, dependendo de implementação rigorosa e **validação humana obrigatória**.
 
@@ -14,13 +14,15 @@ Este documento estabelece o contexto persistente necessário para que o software
 Este documento tem como padrão a conformidade **Standard (AA)**.
 Ao gerar ou revisar código de interface, a IA deve perguntar ao usuário qual perfil de conformidade aplicar, caso não tenha sido especificado:
 
-| Perfil | Alvo | Contraste | Fonte Mín | Targets | Caso de Uso |
+| Perfil | Alvo | Contraste (texto / UI) | Fonte Mín† | Target Mín | Caso de Uso |
 | :--- | :--- | :--- | :--- | :--- | :--- |
-| **🛡️ Shield (AAA)** | WCAG AAA | 7:1 texto, 4.5:1 UI | 14px | 48×48px | Indústrias reguladas, saúde, governo |
-| **⚖️ Standard (AA)** | WCAG AA | 4.5:1 texto, 3:1 UI | 12px | 44×44px | Padrão. Apps em produção, web pública |
-| **🚀 Launchpad (A)** | WCAG A | 3:1 texto (mín) | 10px* | 24×24px* | MVPs, ferramentas internas, protótipos |
+| **🛡️ Shield (AAA)** | WCAG AAA | 7:1 / 3:1 (SC 1.4.6, 1.4.11) | 14px† | 44×44px (SC 2.5.5) · 48×48px† recomendado | Indústrias reguladas, saúde, governo |
+| **⚖️ Standard (AA)** | WCAG AA | 4.5:1 / 3:1 (SC 1.4.3, 1.4.11) | 12px† | 24×24px (SC 2.5.8) · 44×44px† recomendado | Padrão. Apps em produção, web pública |
+| **🚀 Launchpad (A)** | WCAG A | 3:1† (piso da casa) | 10px† | 24×24px† | MVPs, ferramentas internas, protótipos |
 
-*O perfil Launchpad exige documentação explícita no EXCEPTIONS.md para cada critério flexibilizado.*
+*† = **Regra da Casa**, não-normativa: a política ergonômica deste padrão onde a WCAG exige menos — ou nada — naquele nível. A WCAG não define fonte mínima em nenhum nível; o Nível A não define critérios de contraste nem de tamanho de alvo; os alvos de 44–48px vêm da Apple HIG / Material Design. Pular um **SC da WCAG** no seu nível-alvo MUST ser registrado no `EXCEPTIONS.md`; flexibilizar uma **Regra da Casa** é decisão de produto — registre no `A11Y-DECISIONS.md`.*
+
+*O perfil Launchpad exige adicionalmente documentação explícita no `EXCEPTIONS.md` para cada critério flexibilizado abaixo do AA.*
 
 > ⚠️ O perfil **Launchpad (A)** NÃO flexibiliza regras CRÍTICAS (Seção 1). 
 > Operabilidade por teclado, gerenciamento de foco e HTML semântico permanecem 
@@ -41,55 +43,55 @@ Para garantir a integridade técnica, qualquer IA interagindo com este repositó
 - **Protocol for Ambiguity:** Siga o *Complex Component Protocol* em caso de incerteza.
 - **Explain Trade-offs:** Explique os impactos em Acessibilidade vs UX vs Negócio ao sugerir alterações.
 - **UI Component Interrogation:** Antes de adicionar `onClick` a elementos não-semânticos, o agente **MUST** propor sua substituição por elementos nativos ou padrões ARIA completos.
-- **Framework Adaptation:** Os exemplos neste documento usam a sintaxe React/TSX. A IA MUST transpor os padrões para o framework ativo do projeto preservando a equivalência semântica. *Referência: [Framework Mapping](references/guide-framework-mapping.md)*
+- **Framework Adaptation:** Os exemplos neste documento usam a sintaxe React/TSX. Em frameworks **web**, a IA MUST transpor os padrões para o framework ativo do projeto preservando a equivalência semântica. *Referência: [Framework Mapping](references/guide-framework-mapping.md)*
+- **Platform Awareness:** A IA MUST identificar a plataforma-alvo **antes** de carregar qualquer referência. A camada normativa deste documento (Principle Zero, POUR, perfis, severidade, governança) é agnóstica de plataforma; as referências técnicas são web-first. Em plataformas nativas (iOS, Android, React Native, Flutter), as referências web MUST ser lidas como **intenção semântica a traduzir — nunca implementação a copiar**: nada de atributos ARIA ou pixels CSS fora da web. *Referência: [Platform-Native Mapping](references/guide-platform-native.md)*
+- **Component Reuse:** Antes de gerar qualquer componente interativo, a IA MUST verificar se existe implementação no projeto ou no design system e estendê-la. Gerar uma implementação paralela de um padrão existente é uma violação.
+- **Decision Memory:** Escolhas entre alternativas igualmente conformes (ex.: `alertdialog` vs `dialog` para confirmação destrutiva) MUST ser registradas no `A11Y-DECISIONS.md` — indexado por padrão, nunca por tela — e reutilizadas nos turnos seguintes. *Referência: [Registro de Decisões](templates/A11Y-DECISIONS.md)*
 - **Mode Awareness:** Ao gerar código novo, aplique todas as regras proativamente. Ao revisar código existente, identifique as violações, classifique por severidade (Seção 1) e sugira correções pontuais — não proponha reescritas completas a menos que o dano estrutural seja CRITICAL.
 
 ## 3. Technical Standards (POUR Framework)
 
 ### Perceptível (Perceivable)
-*Referências: [Images](references/guide-images.md) | [Content & Timing](references/guide-content-interaction.md) | [Visual Perception & Color](references/guide-visual-perception.md)*
-- **Contraste:** Texto **MUST** ter 4.5:1; Elementos de UI **MUST** ter 3:1. Priorizar **diferença de luminância** real (claro vs escuro) além do matiz.
-- **Alt Text:** Imagens informativas **MUST** ter descrição funcional em `alt`.
+*Referências: [Images](references/guide-images.md) | [Content & Timing](references/guide-content-interaction.md) | [Visual Perception & Color](references/guide-visual-perception.md) | [Responsivo & Zoom](references/guide-responsive-mobile.md)*
+- **Contraste (SC 1.4.3, 1.4.11):** Texto **MUST** ter 4.5:1; componentes de UI e gráficos significativos **MUST** ter 3:1. Priorizar **diferença de luminância** real (claro vs escuro) além do matiz.
+- **Alt Text (SC 1.1.1):** Imagens informativas **MUST** ter descrição funcional em `alt`.
 - **Redundância Semântica:** **MUST NOT** transmitir estado apenas pela cor. O uso de **Ícones + Texto + Cor** (ex: 🔴 Erro) é o padrão obrigatório.
 - **Visual Patterns:** Gráficos e dashboards **MUST** usar texturas ou estilos de linha diferenciados para garantir distinção sem cor.
 
 ### Operável (Operable)
-*Referências: [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md)*
-- **Keyboard:** 100% das funcionalidades **MUST** ser operáveis sem mouse. Evite listeners puramente baseados em ponteiros sem equivalentes para eventos de teclado (`onKeyDown`).
-- **Focus:** O foco **MUST** ser visível, persistente e nunca suprimido via CSS (`outline: none` sem fallback é proibido).
+*Referências: [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md) | [Tabs & Accordions](references/guide-tabs-accordion.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Drag & Drop](references/guide-drag-drop.md) | [Autocomplete](references/guide-autocomplete.md) | [Infinite Scroll](references/guide-infinite-scroll.md)*
+- **Keyboard (SC 2.1.1):** 100% das funcionalidades **MUST** ser operáveis sem mouse. Evite listeners puramente baseados em ponteiros sem equivalentes para eventos de teclado (`onKeyDown`).
+- **Focus (SC 2.4.7, 2.4.11):** O foco **MUST** ser visível, nunca totalmente encoberto por conteúdo do autor (ex.: headers/footers sticky), persistente e nunca suprimido via CSS (`outline: none` sem fallback é proibido).
 - **SPA Routing (Single Page Applications):** Após mudanças de rota baseadas no cliente (Client-side routing), o foco **MUST** ser gerenciado e resetado apropriadamente (ex: enviando foco ao topo ou um H1). Evite foco perdido na tela.
-- **Targets:** Elementos interativos MUST ter um tamanho mínimo de **44x44 CSS pixels**.
-
-  Alvos menores (ex: 24x24) são aceitáveis somente quando:
-  - existe um alvo equivalente maior, ou
-  - o espaçamento ao redor é suficiente para evitar ativação acidental
-- **Motion:** **MUST** respeitar a query CSS de mídia `@media (prefers-reduced-motion)`. Evite animações pesadas de estado durante transições cruciais se a preferência estiver ativa.
+- **Targets (SC 2.5.8):** Elementos interativos MUST ter um tamanho mínimo de **24x24 CSS pixels** — o piso normativo da WCAG 2.2 AA — exceto quando existe um alvo equivalente maior, o espaçamento ao redor evita ativação acidental, ou o alvo está inline no texto.
+  **Regra da Casa†:** projete para **44x44px** (48×48 no Shield), o piso ergonômico compartilhado por Apple HIG e Material Design. No Shield, 44×44 é normativo (SC 2.5.5 AAA).
+- **Motion (SC 2.3.3 AAA — aplicada como Regra da Casa† em todos os perfis):** **MUST** respeitar a query CSS de mídia `@media (prefers-reduced-motion)`. Evite animações pesadas de estado durante transições cruciais se a preferência estiver ativa.
 
 
 ### Compreensível (Understandable)
-*Referências: [Forms & Errors](references/guide-forms.md) | [Content & Microcopy](references/examples-guide-content-interaction.md) | [Visual Perception](references/guide-visual-perception.md)*
-- **Labels:** Formulários **MUST** ter labels explícitas conectadas via `id` e `for`, ou via envelopamento de tag. Evite re-invenções que quebrem os eventos nativos do navegador.
+*Referências: [Forms & Errors](references/guide-forms.md) | [Content & Microcopy](references/guide-content-interaction.md) | [Tables](references/guide-tables.md) | [Toasts & Notifications](references/guide-toasts-notifications.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Tooltips & Popovers](references/guide-tooltips-popovers.md)*
+- **Labels (SC 1.3.1, 3.3.2):** Formulários **MUST** ter labels explícitas conectadas via `id` e `for`, ou via envelopamento de tag. Evite re-invenções que quebrem os eventos nativos do navegador.
 - **Predictability:** O comportamento de navegação **MUST** ser consistente e as interações não devem causar mudanças estruturais repentinas desanunciadas.
-- **Feedback Dinâmico:** Eventos dinâmicos baseados no estado do component (como Toasts, carregamento e sucessos de formulários em AJAX/fetch) **MUST** ser lidos ou informados ativamente através de regiões `aria-live` ou equivalentes modernos (`role="status"`, `role="alert"`).
+- **Feedback Dinâmico (SC 4.1.3):** Eventos dinâmicos baseados no estado do component (como Toasts, carregamento e sucessos de formulários em AJAX/fetch) **MUST** ser lidos ou informados ativamente através de regiões `aria-live` ou equivalentes modernos (`role="status"`, `role="alert"`).
 
 ### Robusto (Robust)
-*Referências: [Governance & Compliance](references/guide-governance.md)*
+*Referências: [Governance & Compliance](references/guide-governance.md) | [Framework Mapping](references/guide-framework-mapping.md) | [Platform-Native Mapping](references/guide-platform-native.md)*
 - **Semantic HTML:** **MUST** preferir elementos nativos (HTML5) a customizados.
 - **Interoperability:** O código **MUST** ser compatível com tecnologias assistivas atuais (ISO 9241-171).
 
 ## 4. Visual Directives (Critérios Rígidos de UI)
 Para garantir a certificação, estas diretrizes visuais são inegociáveis:
-- **Focus Indicator:** O anel de foco **MUST** ter uma espessura mínima de 2px e um contraste de pelo menos 3:1 em relação ao fundo.
-- **Typography:** O texto **MUST NOT** ser menor que a fonte mínima do Compliance Profile ativo (Seção 0.1); 12px no padrão Standard (AA).
-    - *Exceção de Densidade:* Em dashboards complexos ou metadados secundários (badges), permite-se **min 10px**, desde que o contraste seja elevado para **7:1 (WCAG AAA)** para compensar a escala e a flexibilização seja documentada no `EXCEPTIONS.md`, a mesma regra de registro que se aplica às flexibilizações por perfil (Seção 0.1).
+- **Focus Indicator (Regra da Casa† — inspirada no SC 2.4.13 AAA, cuja métrica normativa é área do indicador ≥ um perímetro de 2 CSS px com contraste 3:1 entre os estados focado/não-focado):** O anel de foco **MUST** ter uma espessura mínima de 2px e um contraste de pelo menos 3:1 em relação ao fundo. (O piso AA: foco visível — SC 2.4.7 — e não totalmente encoberto por conteúdo do autor — SC 2.4.11.)
+- **Typography (Regra da Casa† — a WCAG não define fonte mínima em nenhum nível):** O texto **MUST NOT** ser menor que a fonte mínima do Compliance Profile ativo (Seção 0.1); 12px no padrão Standard (AA).
+    - *Exceção de Densidade:* Em dashboards complexos ou metadados secundários (badges), permite-se **min 10px**, desde que o contraste seja elevado para **7:1** como mitigação — um trade-off definido pela política deste padrão, não pela WCAG, que não possui mecanismo de compensação tamanho-por-contraste — e a flexibilização seja documentada no `EXCEPTIONS.md`, a mesma regra de registro que se aplica às flexibilizações por perfil (Seção 0.1).
 - **Target Spacing & Hit Area:** Ver *Seção 3 — Targets* para a regra de tamanho mínimo e exceções. Em UIs densas (ex: tabelas), se o tamanho visual for menor que 44px, a **hit area** (area de clique invisível) **MUST** ser expandida via CSS/padding. Adjacentes **SHOULD** ter 8px de espaçamento.
 
 ## 5. Complex Component Protocol
 Ao identificar um componente não mapeado ou de alta complexidade (ex: Gráficos, Grids Dinâmicos):
 1. **Identify:** Buscar padrão similar no [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/).
-2. **Validate:** Testar protótipo com leitor de tela (Screen Reader).
+2. **Validate:** Solicitar validação humana com leitor de tela — a IA **MUST NOT** alegar que executou esse teste, nem fabricar seus resultados.
 3. **Document:** Documentar o comportamento esperado (teclado e anúncios).
-4. **Scale:** Criar um exemplo reutilizável na pasta `references/`.
+4. **Scale:** Registrar o padrão resolvido no `A11Y-DECISIONS.md` para que componentes futuros o reutilizem em vez de re-derivá-lo.
 
 ## 6. Anti-patterns (Do NOT do this)
 - **Clickable Divs:** **MUST NOT** usar `div` ou `span` para ações de clique. Prefira botões nativos. Se for forçado a usar, repita manualmente o comportamento de um `<button>` (`role`, `tabindex="0"`, event listener de Enter e Space).
@@ -108,13 +110,13 @@ Ao identificar um componente não mapeado ou de alta complexidade (ex: Gráficos
 - [ ] **Technical Check:** Código limpo, testável via linter integrado (`eslint-plugin-jsx-a11y` ou similar) e passando sem violações críticas por motores como `Axe`.
 - [ ] **Tab Order:** Caminho da tecla `Tab` validado manualmente (Garante a ausência de dead-ends no frontend).
 - [ ] **User Flow:** Interações dinâmicas (SPAs) testadas quanto aos feedbacks via `aria-live` em cenários de erro e sucesso sem uso do mouse.
-- [ ] **Zoom:** Flexibilidade de UI preservada utilizando densidade relativa (Rem/Em), sendo adaptável em até 400% zoom.
+- [ ] **Zoom & Reflow:** Texto redimensiona até 200% sem perda de conteúdo ou função (SC 1.4.4); o conteúdo refaz o fluxo (reflow) a 320 CSS px de largura — equivalente a 400% de zoom num viewport de 1280px — sem rolagem bidimensional (SC 1.4.10). Preserve a flexibilidade com densidade relativa (Rem/Em).
 - [ ] **Color & Perception:** Sem perda funcional ao perder o uso exclusivo das cores (simuladores de deficiência de visão).
 
 ---
 ### 📚 Biblioteca de Referências e Modelos
-**Guias Técnicos:** [Imagens](references/guide-images.md) | [Formulários](references/guide-forms.md) | [Botões](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navegação](references/guide-navigation.md) | [Conteúdo](references/guide-content-interaction.md) | [Percepção Visual](references/guide-visual-perception.md) | [Governança](references/guide-governance.md)
+**Guias Técnicos:** [Imagens](references/guide-images.md) | [Formulários](references/guide-forms.md) | [Botões](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navegação](references/guide-navigation.md) | [Conteúdo](references/guide-content-interaction.md) | [Percepção Visual](references/guide-visual-perception.md) | [Tabelas](references/guide-tables.md) | [Tabs & Accordions](references/guide-tabs-accordion.md) | [Tooltips & Popovers](references/guide-tooltips-popovers.md) | [Toasts & Notificações](references/guide-toasts-notifications.md) | [Autocomplete](references/guide-autocomplete.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Drag & Drop](references/guide-drag-drop.md) | [Infinite Scroll](references/guide-infinite-scroll.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Responsivo & Zoom](references/guide-responsive-mobile.md) | [Framework Mapping](references/guide-framework-mapping.md) | [Platform-Native Mapping](references/guide-platform-native.md) | [Perfis de Conformidade](references/guide-compliance-profiles.md) | [Governança](references/guide-governance.md)
 
 **Padrões Externos:** [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/) | [eBay MIND Patterns](https://ebay.github.io/mindpatterns/) | [Deque Axe Core](https://github.com/dequelabs/axe-core)
 
-**Templates Opcionais:** [Report de Acessibilidade](templates/REPORT.md) | [Registro de Exceções](templates/EXCEPTIONS.md)
+**Templates Opcionais:** [Report de Acessibilidade](templates/REPORT.md) | [Registro de Exceções](templates/EXCEPTIONS.md) | [Registro de Decisões](templates/A11Y-DECISIONS.md)

--- a/docs/pt-BR/SETUP.md
+++ b/docs/pt-BR/SETUP.md
@@ -4,6 +4,8 @@ Este guia explica como configurar adequadamente seu assistente de IA (Cursor, Cl
 
 > [!IMPORTANT]  
 > **Regra de Ouro:** O arquivo de configuração do seu ambiente deve conter **APENAS** uma referência apontando para o `A11Y.md`. **NUNCA** copie ou duplique regras de acessibilidade fora do `A11Y.md` — isso previne a fragmentação de regras e garante que a IA sempre carregue o contexto completo.
+>
+> A referência pode apontar para a **URL deste repositório** (sempre atualizada, zero arquivos copiados — o padrão recomendado) ou para uma **cópia local** (offline/fixada). Falantes de inglês podem apontar para `docs/en/A11Y.md`.
 
 ## Referência Rápida
 
@@ -26,7 +28,7 @@ Crie um arquivo `.mdc` dentro do diretório `.cursor/rules/`.
 description: "Contexto persistente de acessibilidade — delega todas as regras para o A11Y.md"
 alwaysApply: true
 ---
-Siga estritamente as regras de acessibilidade definidas no arquivo <aqui vai o caminho para o arquivo A11Y.md na sua máquina ou repositório>.
+Siga estritamente as regras de acessibilidade definidas no arquivo <caminho ou URL do seu A11Y.md — ex.: https://github.com/fecarrico/A11Y.md/blob/main/docs/pt-BR/A11Y.md, ou uma cópia local>.
 ```
 > [!NOTE]  
 > `alwaysApply: true` é crucial. Acessibilidade é uma pré-condição estrita para todo código de UI e não deve depender de padrões glob para ser ativada.
@@ -37,7 +39,7 @@ Adicione uma seção ao seu arquivo `CLAUDE.md` raiz.
 **Arquivo:** `CLAUDE.md`
 ```markdown
 ## Acessibilidade
-Siga estritamente as regras de acessibilidade definidas no arquivo <aqui vai o caminho para o arquivo A11Y.md na sua máquina ou repositório>.
+Siga estritamente as regras de acessibilidade definidas no arquivo <caminho ou URL do seu A11Y.md — ex.: https://github.com/fecarrico/A11Y.md/blob/main/docs/pt-BR/A11Y.md, ou uma cópia local>.
 ```
 
 ## 3. GitHub Copilot
@@ -46,7 +48,7 @@ Adicione a instrução ao arquivo de instruções customizadas do Copilot.
 **Arquivo:** `.github/copilot-instructions.md`
 ```markdown
 ## Acessibilidade
-Siga estritamente as regras de acessibilidade definidas no arquivo <aqui vai o caminho para o arquivo A11Y.md na sua máquina ou repositório>.
+Siga estritamente as regras de acessibilidade definidas no arquivo <caminho ou URL do seu A11Y.md — ex.: https://github.com/fecarrico/A11Y.md/blob/main/docs/pt-BR/A11Y.md, ou uma cópia local>.
 ```
 
 ## 4. Gemini / Antigravity
@@ -54,7 +56,7 @@ Adicione a instrução ao arquivo de regras do agente.
 
 **Arquivo:** `AGENTS.md` ou `.agents/AGENTS.md`
 ```markdown
-Siga estritamente as regras de acessibilidade definidas no arquivo <aqui vai o caminho para o arquivo A11Y.md na sua máquina ou repositório>.
+Siga estritamente as regras de acessibilidade definidas no arquivo <caminho ou URL do seu A11Y.md — ex.: https://github.com/fecarrico/A11Y.md/blob/main/docs/pt-BR/A11Y.md, ou uma cópia local>.
 ```
 
 ## 5. Windsurf
@@ -62,5 +64,5 @@ Crie um arquivo de regra no diretório de regras do Windsurf.
 
 **Arquivo:** `.windsurf/rules/a11y.md`
 ```markdown
-Siga estritamente as regras de acessibilidade definidas no arquivo <aqui vai o caminho para o arquivo A11Y.md na sua máquina ou repositório>.
+Siga estritamente as regras de acessibilidade definidas no arquivo <caminho ou URL do seu A11Y.md — ex.: https://github.com/fecarrico/A11Y.md/blob/main/docs/pt-BR/A11Y.md, ou uma cópia local>.
 ```

--- a/docs/pt-BR/references/guide-buttons.md
+++ b/docs/pt-BR/references/guide-buttons.md
@@ -37,4 +37,4 @@
 
 ## Implicações de Acessibilidade
 - **Affordance:** Botões visualmente distintos ajudam usuários com deficiências cognitivas a identificar pontos de interação.
-- **Precisão:** Áreas de clique grandes (Target Size min 44x44px) são essenciais para usuários mobile e pessoas com deficiências motoras.
+- **Precisão:** Projete áreas de clique de **44x44px** (Regra da Casa — Apple HIG/Material; o piso WCAG AA é 24×24, SC 2.5.8): essenciais para usuários mobile e pessoas com deficiências motoras.

--- a/docs/pt-BR/references/guide-compliance-profiles.md
+++ b/docs/pt-BR/references/guide-compliance-profiles.md
@@ -6,6 +6,9 @@ Acessibilidade não é um monólito. Enquanto a **WCAG 2.2 AA** é o padrão da 
 
 Este guia detalha os três perfis de conformidade suportados pelas regras do `A11Y.md`.
 
+> [!NOTE]
+> **Normativo vs Regras da Casa.** Cada perfil mistura duas camadas: **Critérios de Sucesso da WCAG** no seu nível-alvo (citados por número de SC — pular um exige `EXCEPTIONS.md`) e **Regras da Casa†** — a política ergonômica mais estrita deste padrão (marcadas com †; flexibilizar uma é decisão de produto, registrada no `A11Y-DECISIONS.md`). A WCAG **não define fonte mínima** em nenhum nível, e o Nível A **não define critérios de contraste nem de tamanho de alvo** — todo valor nessas posições abaixo é Regra da Casa.
+
 ---
 
 ## Os Perfis
@@ -25,11 +28,11 @@ Este guia detalha os três perfis de conformidade suportados pelas regras do `A1
 **Instrução IA:** `"Apply Shield Profile (AAA)"`
 
 ### Principais Requisitos (Além do AA)
-- **Contraste:** Texto deve ter um ratio de **7:1** contra o fundo. Textos grandes (18pt+) exigem **4.5:1**.
+- **Contraste (SC 1.4.6):** Texto deve ter um ratio de **7:1** contra o fundo. Textos grandes (18pt+) exigem **4.5:1**. Componentes de UI permanecem em 3:1 (SC 1.4.11 — a WCAG não possui critério AAA de contraste não-textual).
 - **Sem Exceções de Densidade:** Mesmo badges pequenos devem atender ao ratio 7:1.
-- **Targets:** Todos os elementos clicáveis devem ter pelo menos **48×48px**.
-- **Foco:** O indicador de foco deve ser altamente visível (ex: linha sólida 2px com alto contraste) e não depender do padrão do navegador.
-- **Timeouts:** Usuários devem conseguir completar tarefas sem limites de tempo arbitrários.
+- **Targets (SC 2.5.5):** Elementos clicáveis devem ter pelo menos **44×44px** — o mínimo AAA, com as exceções do próprio SC (controle equivalente, alvo inline em texto, controle do user agent, apresentação essencial). **Regra da Casa†:** projete para **48×48px** (norma do Material) e não use exceções de densidade no Shield.
+- **Foco (SC 2.4.13 + Regra da Casa†):** O indicador de foco deve ser altamente visível — linha sólida 2px com contraste 3:1 contra o fundo (Regra da Casa; o 3:1 normativo do SC é medido entre os estados focado/não-focado) — e não depender do padrão do navegador.
+- **Timeouts:** Usuários devem conseguir completar tarefas sem limites de tempo arbitrários, ou ter mecanismos para estender sessões facilmente.
 
 ---
 
@@ -40,11 +43,11 @@ Este guia detalha os três perfis de conformidade suportados pelas regras do `A1
 **Instrução IA:** `"Apply Standard Profile (AA)"`
 
 ### Principais Requisitos
-- **Contraste:** Texto deve ter ratio **4.5:1**. Elementos de UI (bordas, ícones) devem ter **3:1**.
-- **Targets:** Elementos clicáveis devem ter no mínimo **44×44px**. Exceções existem para links inline.
-- **Foco:** O foco deve ser claramente visível.
+- **Contraste (SC 1.4.3, 1.4.11):** Texto deve ter ratio **4.5:1**. Textos grandes, **3:1**. Elementos de UI (bordas, ícones) devem ter **3:1**.
+- **Targets (SC 2.5.8):** Elementos clicáveis devem ter no mínimo **24×24px** — o piso normativo AA, com exceções para links inline e alvos espaçados. **Regra da Casa†:** projete para **44×44px** (norma da Apple HIG / Material).
+- **Foco (SC 2.4.7):** O foco deve ser claramente visível.
 - **HTML Semântico & ARIA:** Aderência estrita aos padrões APG para componentes complexos.
-- **Responsividade:** Deve suportar zoom de até 200% sem perda de conteúdo.
+- **Responsividade (SC 1.4.4, 1.4.10):** Texto deve redimensionar até 200% sem perda de conteúdo ou função, e o conteúdo deve refazer o fluxo a 320 CSS px de largura (≈400% de zoom) sem rolagem bidimensional.
 
 ---
 
@@ -58,9 +61,9 @@ Este guia detalha os três perfis de conformidade suportados pelas regras do `A1
 > O perfil Launchpad **NÃO** significa "sem acessibilidade". Ele ainda exige HTML semântico, operabilidade por teclado e suporte a leitores de tela. Ele apenas flexibiliza critérios visuais estritos.
 
 ### Critérios Flexibilizados (Comparado ao AA)
-- **Contraste:** Apenas um ratio mínimo de **3:1** é forçado.
-- **Targets:** Tamanhos de clique podem ser reduzidos para **24×24px**, se houver espaçamento.
-- **Tipografia:** Fontes até **10px** são toleradas sem compensação estrita de contraste AAA.
+- **Contraste (Regra da Casa†):** Apenas um ratio mínimo de **3:1** é forçado, para evitar ilegibilidade completa. (O Nível A não tem critério de contraste — este piso é política deste padrão, não da WCAG.)
+- **Targets (Regra da Casa†):** Tamanhos de clique podem ser reduzidos para **24×24px**, se houver espaçamento. (O Nível A não tem critério de tamanho de alvo; 24×24 espelha o piso AA do SC 2.5.8.)
+- **Tipografia (Regra da Casa†):** Fontes até **10px** são toleradas sem mitigação estrita de contraste, embora altamente desencorajadas. (A WCAG não define fonte mínima.)
 
 ### Regras Imutáveis (NUNCA flexibilizadas)
 - ❌ `div` ou `span` com `onClick` (armadilha de teclado)

--- a/docs/pt-BR/references/guide-framework-mapping.md
+++ b/docs/pt-BR/references/guide-framework-mapping.md
@@ -6,6 +6,9 @@ O padrão `A11Y.md` usa a sintaxe **React/TSX** em seus exemplos devido à sua p
 
 Quando um agente de IA gera ou revisa código, ele **MUST transpor** esses padrões para o framework ativo do projeto, preservando a equivalência semântica.
 
+> [!IMPORTANT]
+> **Escopo: apenas frameworks web.** Atributos ARIA e eventos de DOM não existem em plataformas nativas. Para alvos iOS, Android, React Native ou Flutter, use o guia [Platform-Native Mapping](guide-platform-native.md) — transpor ARIA para código nativo é uma violação da regra *Platform Awareness* do contrato.
+
 ## Regras Centrais de Tradução
 
 1. **Nativo sobre Customizado:** Sempre prefira a implementação nativa do framework para um elemento semântico em vez de construir um do zero.

--- a/docs/pt-BR/references/guide-platform-native.md
+++ b/docs/pt-BR/references/guide-platform-native.md
@@ -1,0 +1,35 @@
+# Mapeamento de Acessibilidade para Plataformas Nativas
+
+> **Padrão Alvo:** Equivalência Semântica | **Escopo:** iOS (SwiftUI/UIKit), Android (Compose/Views), React Native, Flutter
+
+A camada normativa do `A11Y.md` (Principle Zero, POUR, Perfis de Conformidade, Severidade, Governança) é agnóstica de plataforma — a WCAG 2.2 é escrita para ser neutra em tecnologia, e o [WCAG2ICT](https://www.w3.org/TR/wcag2ict-22/) a mapeia para software não-web. As **referências técnicas**, porém, são web-first. Este guia é a camada de tradução.
+
+## Regras Centrais
+
+1. **Nunca emita idiomas web em plataformas nativas.** Atributos ARIA, roles e pixels CSS não existem em SwiftUI, Compose, React Native ou Flutter. Traduza a *intenção*, não a sintaxe. Inventar híbridos (ex.: `aria-live` no SwiftUI) é violação 🔴 CRITICAL.
+2. **Prefira componentes nativos.** Controles padrão da plataforma (Button, Switch, Alert) já vêm com semântica, comportamento de foco e alvos de toque conformes — o equivalente nativo de "prefira HTML semântico".
+3. **Alvos de toque:** **44×44pt (Apple HIG)** / **48×48dp (Material)** são as normas das plataformas e satisfazem a Regra da Casa deste padrão por default. O piso WCAG (SC 2.5.8, 24×24) segue valendo para controles desenhados do zero.
+4. **Respeite as configurações de acessibilidade do sistema:** escala de fonte (Dynamic Type / unidades `sp` / `textScaler`), Reduzir Movimento e modos de contraste elevado são os equivalentes nativos de zoom, `prefers-reduced-motion` e requisitos de contraste.
+5. **Anuncie mudanças dinâmicas.** Toasts, resultados assíncronos e erros de validação MUST ser anunciados pela API de notificação de acessibilidade da plataforma — o equivalente nativo de `aria-live`.
+
+## Tabela de Tradução (intenção semântica → plataforma)
+
+| Intenção web | iOS (SwiftUI) | Android (Compose) | React Native | Flutter |
+| :--- | :--- | :--- | :--- | :--- |
+| `<button>` / `role="button"` | `Button` ou `.accessibilityAddTraits(.isButton)` | `Button` ou `Modifier.semantics { role = Role.Button }` | `accessibilityRole="button"` | `ElevatedButton` ou `Semantics(button: true)` |
+| Nome acessível (`aria-label`, `alt`) | `.accessibilityLabel("…")` | `contentDescription` / `semantics { contentDescription = "…" }` | `accessibilityLabel` | `Semantics(label: "…")` |
+| `aria-live` / `role="status"` | `AccessibilityNotification.Announcement("…").post()` (iOS 17+; antes: `UIAccessibility.post(notification: .announcement, …)`) | `Modifier.semantics { liveRegion = LiveRegionMode.Polite }` (`announceForAccessibility` está deprecado na API 36) | `accessibilityLiveRegion` (Android) / `AccessibilityInfo.announceForAccessibility(…)` | `SemanticsService.sendAnnouncement(…)` — prefira semântica de live region no Android |
+| Modal + contenção de foco | `.accessibilityAddTraits(.isModal)` (UIKit: `accessibilityViewIsModal`) | `Dialog()` (escopa o foco por default) | `accessibilityViewIsModal` (iOS); esconda o fundo com `importantForAccessibility="no-hide-descendants"` (Android) | `showDialog` (escopo de rota); `Semantics(scopesRoute: true)` para overlays customizados |
+| Heading (`<h1>`–`<h6>`) | `.accessibilityAddTraits(.isHeader)` | `Modifier.semantics { heading() }` | `accessibilityRole="header"` | `Semantics(header: true)` |
+| Estado desabilitado (`disabled`, `aria-disabled`) | `.disabled(true)` (exposto automaticamente) | `enabled = false` | `accessibilityState={{disabled: true}}` | `Semantics(enabled: false)` ou widget desabilitado |
+| Agrupamento de conteúdo relacionado (label + valor) | `.accessibilityElement(children: .combine)` | `Modifier.semantics(mergeDescendants = true) {}` | `accessible={true}` no contêiner | `MergeSemantics` |
+| Gerenciamento de foco após navegação | `@AccessibilityFocusState` | `FocusRequester.requestFocus()` | `AccessibilityInfo.sendAccessibilityEvent(handle, 'focus')` | `FocusNode.requestFocus()` |
+| `prefers-reduced-motion` | Ambiente `accessibilityReduceMotion` / `UIAccessibility.isReduceMotionEnabled` | Respeite a escala de animação do sistema; evite auto-animação gratuita | `AccessibilityInfo.isReduceMotionEnabled()` | `MediaQuery.of(context).disableAnimations` |
+| Zoom de texto (equivalência do SC 1.4.4) | Dynamic Type — use estilos de texto do sistema, nunca tamanhos fixos | Unidades `sp` para texto, nunca `dp` | `allowFontScaling` (default `true` — MUST NOT desabilitar) | `textScaler` do `MediaQuery` — nunca fixe `textScaleFactor: 1.0` |
+
+## Verificação (equivalente nativo da Seção 7)
+
+- [ ] **Passagem de leitor de tela solicitada:** VoiceOver (iOS) / TalkBack (Android) — validação humana; a IA MUST NOT alegar que os executou.
+- [ ] **Escala de fonte:** a UI sobrevive ao maior tamanho de fonte do sistema sem truncamento ou sobreposição.
+- [ ] **Ordem de foco/swipe:** a navegação sequencial segue a ordem visual/lógica.
+- [ ] **Anúncios:** feedback assíncrono audível sem tocar na tela.

--- a/docs/pt-BR/references/guide-responsive-mobile.md
+++ b/docs/pt-BR/references/guide-responsive-mobile.md
@@ -1,9 +1,12 @@
-# Guia de Acessibilidade Mobile & Responsivo
+# Guia de A11y para Web Responsiva & Zoom
 
-> **Escopo:** Layout & Touch
+> **Escopo:** Layout web, zoom de navegador & toque. Para apps móveis **nativos** (iOS, Android, React Native, Flutter), consulte o [Platform-Native Mapping](guide-platform-native.md) — este guia cobre apenas o navegador.
 
 ## Regras Centrais
-1. **Zoom:** A UI MUST não quebrar até 200% de zoom.
-2. **Orientação:** MUST não travar a tela em retrato ou paisagem.
-3. **Alvos de Toque:** Mínimo de 44x44px para áreas tocáveis.
-4. **Gestos:** Gestos complexos (swipe) MUST ter botões equivalentes de clique.
+1. **Redimensionamento de Texto (SC 1.4.4):** A UI MUST NOT quebrar, cortar ou perder função até **200% de zoom de texto**.
+2. **Reflow (SC 1.4.10):** O conteúdo MUST refazer o fluxo a **320 CSS px de largura** (equivalente a 400% de zoom num viewport de 1280px) sem rolagem bidimensional — exceto conteúdo que exige layout 2D (tabelas de dados, mapas, gráficos).
+3. **Orientação (SC 1.3.4):** MUST NOT travar a orientação em paisagem ou retrato, a menos que essencial.
+4. **Alvos de Toque (SC 2.5.8 + Regra da Casa†):** 24×24 CSS px é o piso normativo AA; projete para **44×44px** em superfícies de toque (norma Apple HIG / Material).
+5. **Gestos (SC 2.5.1):** Gestos complexos (swipes, multiponto) MUST ter equivalentes simples de ponteiro único.
+
+*† = Regra da Casa: política ergonômica deste padrão além do piso WCAG — ver `A11Y.md` §0.1.*

--- a/docs/pt-BR/templates/A11Y-DECISIONS.md
+++ b/docs/pt-BR/templates/A11Y-DECISIONS.md
@@ -1,0 +1,18 @@
+# Registro de Decisões A11Y (Memória de Padrões)
+
+> **Propósito:** memória entre turnos das escolhas entre **alternativas igualmente conformes**. Duas implementações podem passar no `A11Y.md` e no axe e ainda divergir (`role` diferente, padrão de foco diferente, texto de anúncio diferente) — vinte modais conformes, zero coerência. Este arquivo evita isso.
+
+## Regras para a IA
+
+1. **Registre apenas o que não é derivável** das regras do `A11Y.md` nem do próprio código. Landmarks, headings e presença de alt são verificáveis por máquina — **NÃO** pertencem a este arquivo.
+2. **Indexe por padrão, nunca por tela.** ✅ *"Modal de confirmação destrutiva → `alertdialog`"* · ❌ *"O modal de contestação faz X"*.
+3. **Uma linha por decisão:** padrão → escolha → porquê curto.
+4. **Leia antes de construir:** antes de gerar qualquer componente interativo, consulte este registro e reutilize o padrão registrado (ver *Component Reuse* no AI Behavior Contract).
+5. **Nunca bifurque em silêncio:** se um requisito novo contradiz uma decisão registrada, pergunte ao usuário — não crie uma variante paralela.
+6. **Mantenha enxuto:** dezenas de linhas, não centenas. Este arquivo divide o orçamento de contexto com o Lazy Loading; se passar de ~40 entradas, consolide.
+
+## Decisões
+
+<!-- Adicione entradas abaixo. Formato: - **Padrão** → escolha — porquê. (data) -->
+
+- **Modal de confirmação destrutiva** → `role="alertdialog"`, foco inicial no botão não-destrutivo, foco retorna ao acionador — semântica de interrupção conforme APG. *(exemplo — substitua pela primeira decisão real do seu projeto)*

--- a/docs/pt-BR/templates/REPORT.md
+++ b/docs/pt-BR/templates/REPORT.md
@@ -31,7 +31,7 @@ Caminhos críticos da funcionalidade e validação via Leitores de Tela.
 Testes que validam contraste e estrutura visual (sem dependência de cores).
 - [ ] **Contraste de Texto & UI:** Todos os textos possuem ratio 4.5:1 e componentes essenciais 3:1?
 - [ ] **Redundância:** Erros e alertas não comunicam informações exclusivas por meio de cores *(ex: sempre usam Cor + Ícone + Texto)*.
-- [ ] **Scale / Zoom:** Ao ampliar a tela em 400%, tudo continuou operável e sem bloqueios (overrides de tela)?
+- [ ] **Scale / Zoom:** Texto redimensionado a 200% sem perda (SC 1.4.4) e conteúdo em reflow a 320 CSS px — ≈400% de zoom num viewport de 1280px (SC 1.4.10) — com tudo operável e sem rolagem bidimensional?
 
 ---
 ## 📝 Notas de Avaliação ou Bloqueios Conhecidos


### PR DESCRIPTION
## What this release does

Three approved roadmap items plus a normative-precision audit, in both languages (en / pt-BR):

### 1. WCAG requirements and House Rules are now explicitly separated
Every rule in the core file and profile guide now cites its WCAG 2.2 Success Criterion by number. Everything stricter than the target level is labeled **House Rule†** and kept as this standard's ergonomic policy:
- Target size: the AA requirement is **24×24px (SC 2.5.8)**; 44×44px (Apple HIG / Material) stays as the design guidance. Under Shield, 44×44 is normative (SC 2.5.5 AAA).
- Font floors (14/12/10px) and the Density Exception are labeled House Rules — WCAG defines no minimum font size.
- Shield corrected: 7:1 text (SC 1.4.6), UI components 3:1 (SC 1.4.11 — WCAG has no AAA non-text contrast criterion).
- Zoom unified: 200% text resize (SC 1.4.4) + reflow at 320 CSS px (SC 1.4.10) across core, guides, and REPORT template (was inconsistently 200%/400%).
- Focus rules now include SC 2.4.11 (Focus Not Obscured), new in WCAG 2.2 AA.

### 2. Platform Awareness (approved 2026-07-18)
New contract rule: the AI must identify the target platform before loading references; on native platforms, web references are semantic intent to translate — never implementation to copy. New **`guide-platform-native.md`** maps web semantics (roles, labels, live regions, focus, reduced motion, text scaling) to iOS (SwiftUI), Android (Compose), React Native, and Flutter — API names verified against current official docs (deprecated APIs like `announceForAccessibility`/API 36, `SemanticsService.announce`, `setAccessibilityFocus` are avoided or flagged).

### 3. Component Reuse + Decision Memory (approved 2026-07-18)
The standard already discouraged rebuilding complex components from scratch (the *Reinventing the Complex Wheel* anti-pattern); production data later confirmed the failure mode it points at — markdown-as-context systems inducing agents to recreate components instead of reusing them (Atlassian's published test of the DESIGN.md spec). These two contract rules close the remaining gap: the AI must extend existing project components, and choices between equally conformant alternatives are recorded in the new lean, pattern-indexed **`templates/A11Y-DECISIONS.md`** and reused across turns.

### Also in this release
- The 10 guides added in 1.0.0 were unreachable via Lazy Loading (never linked from the core) — all 21 guides are now linked from the POUR sections.
- Quick Start is now **rule-first**: one line in the agent's config pointing at this repository (or a local copy for offline/pinned use).
- Fixed a broken pt-BR reference (`examples-guide-content-interaction.md`) and the "12+ frameworks" claim from the 1.0.0 notes.
- The AI contract now forbids claiming or fabricating screen-reader test results (human validation is requested, not simulated).

Core file grows 10.7KB → 15.6KB (~3.9k tokens) — the cost of SC traceability, 3 new rules, and the full guide index.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
