### PR TITLE
v1.2.0 — Artifact triggers in the behavior contract (from a field post-mortem)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,23 @@ All notable changes to the A11y Guidelines project will be documented in this fi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-08-02
+
+> Driven by a documented field post-mortem: an agent applied the standard to a real project for weeks, generated and maintained `A11Y-DECISIONS.md`, and never produced a `REPORT.md` or an `EXCEPTIONS.md`. The artifact that existed was the only one named inside a rule of the AI Behavior Contract. Obligation was not the variable — placement and trigger were.
 
 ### Added
+- **Exception Memory (AI Behavior Contract):** accepting a WCAG SC violation now requires creating or updating `EXCEPTIONS.md` **in the same turn**, from the template, with risk owner, approver, tracking issue and expiry. An accepted-but-unrecorded exception is a contract violation, not a pending decision.
+- **Release Evidence (AI Behavior Contract):** before any delivery to an end user — build, deploy, shared artifact, tag — the AI must verify a `REPORT.md` newer than the last interface change, or state that the delivery carries no conformance evidence. Event trigger, so it fires in continuous-delivery projects where a "final delivery" phase never arrives.
+- **Artifacts Present** checkpoint, now first in the Verification Workflow: the six existing checkpoints verified the interface, none verified that evidence of it exists.
+- **Headless-agent clause** (Section 7 and `REPORT.md`): an agent without a browser must still produce the report, marking unverifiable checkpoints and naming who must run them. A partial, honest report is evidence; a missing report is not.
+- **Marking legend in `REPORT.md`:** `[x]` verified with evidence · `[!]` verified and failed · `[~]` partial · `[ ]` not verified, reason required. Removes the ambiguity of an empty checkbox and the incentive to mark what "is probably fine".
+- **Governance guide, Section 0 — where a rule belongs:** anything the AI must DO belongs in the behavior contract with an explicit event trigger; guides carry depth, never sole obligation.
 - **ARIA Soup anti-pattern (Section 6):** named prohibition of decorative/redundant ARIA — no ARIA where native HTML provides the semantics, no redundant roles, no static never-updated ARIA states. Response to the WebAIM Million 2026 finding (133+ ARIA attributes per page, 6× since 2019, with more ARIA correlating with more errors).
 - **Benchmark pre-registration (`benchmark/`):** methodology and verbatim prompts for measuring whether A11Y.md reduces automatically detectable violations in AI-generated UI — published before any data collection.
 
 ### Changed
+- **Lazy Context Loading no longer covers `templates/`:** `references/` is per-component context (load on demand); `templates/` is lifecycle context and must be loaded when its triggering event occurs. Adds **template fidelity** — artifacts are created from the template files, never deduced from prose, resolving upstream first when the folder is absent.
+- **"Optional Templates" renamed to "Project Artifacts"** *(versioned, not optional)*, each with its trigger. The index label contradicted a normative body that says MUST four times.
 - **`templates/EXCEPTIONS.md`:** every exception now requires a **risk owner**, an **approver**, a **tracking issue** and an **expiry date**, at the narrowest practical scope; in review mode the AI flags expired exceptions as 🟠 HIGH technical debt. An exception is temporary and is never silently suppressed.
 
 ## [1.1.0] - 2026-07-20

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ We treat `.gitignore`, `eslint`, and `CLAUDE.md` as canonical truths in our repo
 
 ## ⚡ Core Features
 
-- 🧠 **11-Rule AI Behavioral Contract:** A strict set of deterministic constraints that force the AI to act as a semantic translator (Framework Adaptation, Platform Awareness), reuse the project's existing components instead of recreating them (Component Reuse + Decision Memory), and stop generating dangerous anti-patterns (like "clickable divs").
+- 🧠 **13-Rule AI Behavioral Contract:** A strict set of deterministic constraints that force the AI to act as a semantic translator (Framework Adaptation, Platform Awareness), reuse the project's existing components instead of recreating them (Component Reuse + Decision Memory), produce the evidence of its own work (Exception Memory + Release Evidence), and stop generating dangerous anti-patterns (like "clickable divs").
 - 🛡️ **Modular Compliance Profiles:** Support for Shield (AAA), Standard (AA), and **Launchpad (A)** — each separating what WCAG actually requires (cited by Success Criterion) from this standard's stricter **House Rules**. The Launchpad profile allows startups to build rapid MVPs by relaxing visual constraints without ever sacrificing critical semantic structure.
 - 📚 **Lazy Context Loading:** 21 reference guides (WAI-ARIA APG) that act as an actionable database. The AI is programmed to load only the guides it needs on-demand, saving tokens and maintaining sharp focus.
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ Reading about accessibility is the first step, injecting it into your code is th
 
 👉 **<a href="https://github.com/fecarrico/A11Y.md/wiki/Setup-and-Integration" target="_blank">Read the full Setup and Integration guide on our Wiki.</a>**
 
+> **A11Y.md is portable markdown, and stays that way.** It has to work for anyone whose agent can read a file — no runtime, no install, no build step. The optional scripts in [`tools/`](./tools) are a convenience for teams that want a CI gate; running them is never a requirement of the standard.
+
 ---
 
 ## 📖 Official Documentation (The Wiki)

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -50,6 +50,10 @@ Ler sobre acessibilidade é o primeiro passo, injetá-la no código é o objetiv
 
 ---
 
+> **O A11Y.md é markdown portátil, e continua sendo.** Ele precisa funcionar para qualquer pessoa cujo agente saiba ler um arquivo — sem runtime, sem instalação, sem build. Os scripts opcionais em [`tools/`](./tools) são uma conveniência para times que querem um gate de CI; executá-los nunca é requisito do padrão.
+
+---
+
 ## 📖 Documentação Oficial (A Wiki)
 
 A arquitetura completa, protocolos e exemplos práticos estão profundamente documentados na nossa Wiki no GitHub (em Inglês).

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -29,7 +29,7 @@ Nós tratamos arquivos como `.gitignore`, `eslint` e `CLAUDE.md` como verdades c
 
 ## ⚡ Core Features (Inovações)
 
-- 🧠 **Contrato Comportamental da IA (11 Regras):** Restrições determinísticas que forçam a IA a atuar como tradutora semântica (Framework Adaptation, Platform Awareness), a reutilizar os componentes existentes do projeto em vez de recriá-los (Component Reuse + Decision Memory) e a parar de gerar anti-padrões destrutivos (como `divs` clicáveis).
+- 🧠 **Contrato Comportamental da IA (13 Regras):** Restrições determinísticas que forçam a IA a atuar como tradutora semântica (Framework Adaptation, Platform Awareness), a reutilizar os componentes existentes do projeto em vez de recriá-los (Component Reuse + Decision Memory), a produzir a evidência do próprio trabalho (Exception Memory + Release Evidence) e a parar de gerar anti-padrões destrutivos (como `divs` clicáveis).
 - 🛡️ **Compliance Profiles Modulares:** Suporte aos perfis Shield (AAA), Standard (AA) e **Launchpad (A)** — cada um separando o que a WCAG realmente exige (citado por Critério de Sucesso) das **Regras da Casa** mais estritas deste padrão. O perfil Launchpad permite que startups construam MVPs rápidos relaxando regras visuais cosméticas, sem nunca sacrificar a estrutura semântica crítica.
 - 📚 **Lazy Context Loading:** 21 guias de referência (WAI-ARIA APG). A IA é programada para carregar apenas os guias necessários sob demanda, economizando tokens e mantendo o foco afiado.
 

--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -1,5 +1,5 @@
 # A11y Guidelines: Accessibility as a Baseline
-> **Version:** 1.1.0 | **Target Standard:** WCAG 2.2 AA | **Last Updated:** 2026-07-20
+> **Version:** 1.2.0 | **Target Standard:** WCAG 2.2 AA | **Last Updated:** 2026-08-02
 
 This document establishes the persistent context required so that the software **can be certified** under the **WCAG 2.2 AA**, **ISO 9241-171**, **ADA**, and **EAA** standards, depending on rigorous implementation and **mandatory human validation**.
 
@@ -38,7 +38,7 @@ Evaluate the impact of any design or implementation decision following these lev
 ## 2. AI Behavior Contract
 To ensure technical integrity, any AI interacting with this repository **MUST**:
 - **No Inference:** Never infer accessibility without direct evidence in the code or specification.
-- **Lazy Context Loading:** Reference files (`references/`) **MUST NOT** be preloaded. They **MUST** be consulted only when the task explicitly involves that component type. The `A11Y.md` alone is sufficient for most code generation tasks. If the `references/` and `templates/` folders are not available locally (e.g., only this file was copied into the project), resolve the relative links against the upstream repository: `https://github.com/fecarrico/A11Y.md/tree/main/docs/en/`.
+- **Lazy Context Loading:** Reference files (`references/`) **MUST NOT** be preloaded — they are *per-component* context, consulted only when the task explicitly involves that component type. The `A11Y.md` alone is sufficient for most code generation tasks. **This rule does NOT apply to `templates/`:** templates are *lifecycle* context and **MUST** be loaded when their triggering event occurs (a decision made, an exception accepted, a delivery shipped), whatever component is being worked on. **Template fidelity:** project artifacts **MUST** be created from the files in `templates/`, never deduced from a prose description. If either folder is unavailable locally (e.g., only this file was copied into the project), resolve the relative links against the upstream repository *before* creating the artifact: `https://github.com/fecarrico/A11Y.md/tree/main/docs/en/`.
 - **Reference APG:** Prioritize patterns from the [WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/).
 - **Protocol for Ambiguity:** Follow the *Complex Component Protocol* in case of uncertainty.
 - **Explain Trade-offs:** Explain impacts on Accessibility vs UX vs Business when suggesting changes.
@@ -47,6 +47,8 @@ To ensure technical integrity, any AI interacting with this repository **MUST**:
 - **Platform Awareness:** The AI MUST identify the target platform **before** loading any reference. The normative layer of this document (Principle Zero, POUR, profiles, severity, governance) is platform-agnostic; the technical references are web-first. On native platforms (iOS, Android, React Native, Flutter), web references MUST be read as **semantic intent to translate — never implementation to copy**: no ARIA attributes or CSS pixels outside the web. *Reference: [Platform-Native Mapping](references/guide-platform-native.md)*
 - **Component Reuse:** Before generating any interactive component, the AI MUST check for an existing implementation in the project or its design system and extend it. Generating a parallel implementation of an existing pattern is a violation.
 - **Decision Memory:** Choices between equally conformant alternatives (e.g., `alertdialog` vs `dialog` for a destructive confirmation) MUST be recorded in `A11Y-DECISIONS.md` — indexed by pattern, never by screen — and reused in later turns. *Reference: [Decisions Log](templates/A11Y-DECISIONS.md)*
+- **Exception Memory:** When knowingly accepting a violation of a WCAG SC at the target level, the AI **MUST** create or update `EXCEPTIONS.md` **in the same turn**, from `templates/EXCEPTIONS.md`, with risk owner, approver, tracking issue and expiry. An accepted-but-unrecorded exception is a contract violation, not a pending decision. *(Relaxing a House Rule† is a product decision — it belongs in `A11Y-DECISIONS.md`, not here.)*
+- **Release Evidence:** Before any delivery to an end user — published build, deploy, shared artifact, tag — the AI **MUST** verify that a `REPORT.md` exists, was generated from `templates/REPORT.md`, and is newer than the last interface change. If it does not exist, the AI **MUST** generate it or state explicitly that the delivery carries no conformance evidence. In continuous-delivery projects this rule is what triggers the report: waiting for a "final delivery" event that never happens is not compliance.
 - **Mode Awareness:** When generating new code, apply all rules proactively. When reviewing existing code, identify violations, classify by severity (Section 1), and suggest targeted fixes — do not propose full rewrites unless the structural damage is CRITICAL. If an `EXCEPTIONS.md` exists, consult it: an entry there is a legitimate dispensation, but an entry past its expiry date MUST be flagged as 🟠 HIGH technical debt.
 
 ## 3. Technical Standards (POUR Framework)
@@ -108,6 +110,7 @@ When identifying an unmapped or highly complex component (e.g., Charts, Dynamic 
 
 ## 7. Verification Workflow (Definition of Done)
 *Compliance must be verified through these steps (Refer to the [**Report Template**](templates/REPORT.md) for final QA details and the [**Governance Guide**](references/guide-governance.md) for audit readiness):*
+- [ ] **Artifacts Present:** `REPORT.md` exists, is filled from the template, and is newer than the last interface change. If any deviation was accepted, `EXCEPTIONS.md` exists. All project artifacts are versioned, never gitignored.
 - [ ] **Technical Check:** Clean code, testable via integrated linter (`eslint-plugin-jsx-a11y` or similar), and passing without critical violations through engines like `Axe`.
 - [ ] **Tab Order:** `Tab` key path manually validated (Ensures absence of frontend dead-ends).
 - [ ] **User Flow:** Dynamic interactions (SPAs) tested for feedback via `aria-live` in error and success scenarios without mouse use.
@@ -115,10 +118,12 @@ When identifying an unmapped or highly complex component (e.g., Charts, Dynamic 
 - [ ] **Color & Perception:** No functional loss when losing the exclusive use of colors (vision deficiency simulators).
 - [ ] **Exceptions Audit:** `EXCEPTIONS.md` reviewed — every active entry has a risk owner, approver, tracking issue and expiry; no expired entries left unaddressed.
 
+> **Agents without a browser.** Several checkpoints above require a person with a browser or assistive technology. A headless agent **MUST** still produce the `REPORT.md`, marking those items `[ ]` with the reason and naming who must run them. A partial, honest report is evidence; a missing report is not. The AI **MUST NOT** mark as verified any item whose evidence it cannot reproduce.
+
 ---
 ### 📚 Reference & Templates Library
 **Technical Guides:** [Images](references/guide-images.md) | [Forms](references/guide-forms.md) | [Buttons](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navigation](references/guide-navigation.md) | [Content](references/guide-content-interaction.md) | [Visual Perception](references/guide-visual-perception.md) | [Tables](references/guide-tables.md) | [Tabs & Accordions](references/guide-tabs-accordion.md) | [Tooltips & Popovers](references/guide-tooltips-popovers.md) | [Toasts & Notifications](references/guide-toasts-notifications.md) | [Autocomplete](references/guide-autocomplete.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Drag & Drop](references/guide-drag-drop.md) | [Infinite Scroll](references/guide-infinite-scroll.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Responsive & Zoom](references/guide-responsive-mobile.md) | [Framework Mapping](references/guide-framework-mapping.md) | [Platform-Native Mapping](references/guide-platform-native.md) | [Compliance Profiles](references/guide-compliance-profiles.md) | [Governance](references/guide-governance.md)
 
 **External Standards:** [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/) | [eBay MIND Patterns](https://ebay.github.io/mindpatterns/) | [Deque Axe Core](https://github.com/dequelabs/axe-core)
 
-**Optional Templates:** [Accessibility Report](templates/REPORT.md) | [Exceptions Log](templates/EXCEPTIONS.md) | [Decisions Log](templates/A11Y-DECISIONS.md)
+**Project Artifacts** *(versioned, not optional — see Sections 2 and 7):* [Accessibility Report](templates/REPORT.md) · before each delivery | [Exceptions Log](templates/EXCEPTIONS.md) · whenever a deviation is accepted | [Decisions Log](templates/A11Y-DECISIONS.md) · at each choice between conformant alternatives

--- a/docs/en/references/guide-governance.md
+++ b/docs/en/references/guide-governance.md
@@ -2,6 +2,16 @@
 
 > Scope: Static verification, VPAT strategy, ADA/EAA compliance, EN 301 549, and external audit readiness.
 
+## 0. Where a rule belongs (design principle for this standard)
+
+> **Field evidence (2026-08-01):** in a documented post-mortem of a real project, an agent applied Sections 0–6 correctly and produced no `REPORT.md` or `EXCEPTIONS.md` at all. The artifact that *was* produced (`A11Y-DECISIONS.md`) was the only one named inside a rule of the **AI Behavior Contract**. The variable was not obligation — the other two were already MUST elsewhere — it was **where the filename appeared**.
+
+Agents treat Section 2 as an executable contract and everything else as reference material. Therefore, when extending this standard:
+
+- **Anything the AI must DO** — create a file, refuse an action, check something before proceeding — belongs in the **AI Behavior Contract (Section 2)**, with an explicit trigger event.
+- **Sections 7 and the reference guides** carry depth, verification detail and rationale — they explain and expand, but must never be the *only* place an obligation exists.
+- Prefer **event triggers** ("before any delivery to an end user") over **phase triggers** ("at final delivery"): continuous-delivery projects never reach a phase, so a phase-triggered rule never fires.
+
 ## 1. Static Verification (The Engineering Minimum)
 Primary verification does not consist of dictating rigid rules in a *specific pipeline*, but holding the development environment (Be it the Dev or the AI running in real-time) accountable for fast static validation tests.
 - **Code Standard:** The code *must* necessarily pass through linters or accessibility-focused evaluators (like `eslint-plugin-jsx-a11y` or the `axe` engine) without displaying critical/serious violations before code consolidation.

--- a/docs/en/references/guide-governance.md
+++ b/docs/en/references/guide-governance.md
@@ -31,7 +31,8 @@ When creating custom complex widgets, the developer (or AI) must include a comme
 To prepare subsystems for external certification and audit:
 1. **Inventory:** Consolidate a list or storybook of the key visual components of the flow and their behaviors with assistive technologies.
 2. **Keyboard Path:** Prevent Dead-ends through clear and planned mapping of the visual layout order (`Tab`).
-3. **Standard Audit:** In case of final delivery, the checklist in [**`templates/REPORT.md`**](../templates/REPORT.md) *must* be operated as "Definition of Done".
+3. **Standard Audit:** The checklist in [**`templates/REPORT.md`**](../templates/REPORT.md) **MUST** be operated as "Definition of Done" **before any delivery to an end user** — a published build, a deploy, a shared artifact, a tag — not only at a "final delivery" that continuously delivered projects never reach (see *Release Evidence*, `A11Y.md` §2).
+4. **One living report, not one per publish:** the report tracks the **interface**, not the release count. If nothing changed since the last one, it stands as is. When the interface changes, update the date and revisit only the entries that change affects: any checkpoint whose evidence the change invalidates goes back to `[ ]` or `[~]` until re-verified. Human checkpoints (screen reader, color simulator) keep their `[x]` and the date of the session that produced them, and are re-run when the flow they covered changes.
 
 ## 5. Reporting & Liability (VPAT Strategy)
 Projects targeting the US market must be Section 508 compliant:

--- a/docs/en/templates/REPORT.md
+++ b/docs/en/templates/REPORT.md
@@ -14,7 +14,8 @@ This report compiles the compliance evidence for a given *Feature*, ensuring its
 
 ## 📌 Validation Context
 - **Feature/Epic:** [e.g., Integrated Checkout]
-- **Test Date:** [MM/DD/YYYY]
+- **Test Date:** [MM/DD/YYYY — the date of this revision; update it whenever the interface changes]
+- **Covers interface as of:** [commit / build / version this report was verified against]
 - **Compliance Status:** [✅ PASS | ⚠️ CONDITIONAL (Passes with Exceptions) | 🚫 FAIL]
 
 ## 1. Technical Verification (Automated & Semantics)

--- a/docs/en/templates/REPORT.md
+++ b/docs/en/templates/REPORT.md
@@ -4,6 +4,12 @@ This report compiles the compliance evidence for a given *Feature*, ensuring its
 
 > This report is a **versioned project record** — never add it to `.gitignore`. Evidence hidden from version control is not evidence: QA and leadership verify it before release, and audits read it after.
 
+> **Marking legend (mandatory):**
+> `[x]` verified, with the evidence described beside it · `[!]` verified and **failed** (fix it, or open an entry in `EXCEPTIONS.md`) · `[~]` partially verified, with what is missing written down · `[ ]` **not verified** — the reason MUST be written beside it.
+> Marking `[x]` without reproducible evidence invalidates the whole report.
+
+> **Headless agents.** An AI without a browser MUST still produce this report, marking `[ ]` every checkpoint that requires a browser or assistive technology, with the reason and who must run it. A partial, honest report is evidence; a missing report is not. Overall status is CONDITIONAL — never PASS — while any `[ ]` or `[!]` remains.
+
 ---
 
 ## 📌 Validation Context

--- a/docs/pt-BR/A11Y.md
+++ b/docs/pt-BR/A11Y.md
@@ -1,5 +1,5 @@
 # A11y Guidelines: Accessibility as a Baseline
-> **Versão:** 1.1.0 | **Padrão Alvo:** WCAG 2.2 AA | **Última Atualização:** 2026-07-20
+> **Versão:** 1.2.0 | **Padrão Alvo:** WCAG 2.2 AA | **Última Atualização:** 2026-08-02
 
 Este documento estabelece o contexto persistente necessário para que o software **possa ser certificado** segundo as normas **WCAG 2.2 AA**, **ISO 9241-171**, **ADA** e **EAA**, dependendo de implementação rigorosa e **validação humana obrigatória**.
 
@@ -38,7 +38,7 @@ Avalie o impacto de qualquer decisão de design ou implementação seguindo este
 ## 2. AI Behavior Contract
 Para garantir a integridade técnica, qualquer IA interagindo com este repositório **MUST**:
 - **No Inference:** Nunca inferir acessibilidade sem evidência direta no código ou especificação.
-- **Lazy Context Loading:** Os arquivos de referência (`references/`) **MUST NOT** ser carregados preventivamente. Eles **MUST** ser consultados apenas quando a tarefa envolver explicitamente aquele tipo de componente. O `A11Y.md` sozinho é suficiente para a maioria das tarefas de geração de código. Se as pastas `references/` e `templates/` não estiverem disponíveis localmente (ex.: apenas este arquivo foi copiado para o projeto), resolva os links relativos contra o repositório upstream: `https://github.com/fecarrico/A11Y.md/tree/main/docs/pt-BR/`.
+- **Lazy Context Loading:** Os arquivos de referência (`references/`) **MUST NOT** ser carregados preventivamente — são contexto *por componente*, consultados apenas quando a tarefa envolver explicitamente aquele tipo de componente. O `A11Y.md` sozinho é suficiente para a maioria das tarefas de geração de código. **Esta regra NÃO se aplica a `templates/`:** os templates são contexto de *ciclo de vida* e **MUST** ser carregados quando o evento que os dispara ocorre (decisão tomada, exceção aceita, entrega feita), independentemente de qual componente está sendo trabalhado. **Fidelidade ao template:** os artefatos do projeto **MUST** ser criados a partir dos arquivos em `templates/`, nunca deduzidos de uma descrição em prosa. Se alguma das pastas não estiver disponível localmente (ex.: apenas este arquivo foi copiado para o projeto), resolva os links relativos contra o repositório upstream *antes* de criar o artefato: `https://github.com/fecarrico/A11Y.md/tree/main/docs/pt-BR/`.
 - **Reference APG:** Priorize padrões do [WAI-ARIA Authoring Practices Guide (APG)](https://www.w3.org/WAI/ARIA/apg/).
 - **Protocol for Ambiguity:** Siga o *Complex Component Protocol* em caso de incerteza.
 - **Explain Trade-offs:** Explique os impactos em Acessibilidade vs UX vs Negócio ao sugerir alterações.
@@ -47,6 +47,8 @@ Para garantir a integridade técnica, qualquer IA interagindo com este repositó
 - **Platform Awareness:** A IA MUST identificar a plataforma-alvo **antes** de carregar qualquer referência. A camada normativa deste documento (Principle Zero, POUR, perfis, severidade, governança) é agnóstica de plataforma; as referências técnicas são web-first. Em plataformas nativas (iOS, Android, React Native, Flutter), as referências web MUST ser lidas como **intenção semântica a traduzir — nunca implementação a copiar**: nada de atributos ARIA ou pixels CSS fora da web. *Referência: [Platform-Native Mapping](references/guide-platform-native.md)*
 - **Component Reuse:** Antes de gerar qualquer componente interativo, a IA MUST verificar se existe implementação no projeto ou no design system e estendê-la. Gerar uma implementação paralela de um padrão existente é uma violação.
 - **Decision Memory:** Escolhas entre alternativas igualmente conformes (ex.: `alertdialog` vs `dialog` para confirmação destrutiva) MUST ser registradas no `A11Y-DECISIONS.md` — indexado por padrão, nunca por tela — e reutilizadas nos turnos seguintes. *Referência: [Registro de Decisões](templates/A11Y-DECISIONS.md)*
+- **Exception Memory:** Ao aceitar conscientemente uma violação de SC da WCAG no nível-alvo, a IA **MUST** criar ou atualizar o `EXCEPTIONS.md` **no mesmo turno**, a partir de `templates/EXCEPTIONS.md`, com dono do risco, aprovador, issue de rastreio e expiração. Uma exceção aceita e não registrada é violação do contrato, não decisão pendente. *(Flexibilizar uma Regra da Casa† é decisão de produto — vai no `A11Y-DECISIONS.md`, não aqui.)*
+- **Release Evidence:** Antes de qualquer entrega ao usuário final — build publicado, deploy, artefato compartilhado, tag —, a IA **MUST** verificar que existe um `REPORT.md` gerado a partir de `templates/REPORT.md` e mais recente que a última mudança de interface. Se não existir, a IA **MUST** gerá-lo ou declarar explicitamente que a entrega está sem evidência de conformidade. Em projetos de entrega contínua, é esta regra que dispara o relatório: esperar por um evento de "entrega final" que nunca acontece não é conformidade.
 - **Mode Awareness:** Ao gerar código novo, aplique todas as regras proativamente. Ao revisar código existente, identifique as violações, classifique por severidade (Seção 1) e sugira correções pontuais — não proponha reescritas completas a menos que o dano estrutural seja CRITICAL. Se existir um `EXCEPTIONS.md`, consulte-o: uma entrada lá é dispensa legítima, mas entrada com expiração vencida MUST ser sinalizada como débito técnico 🟠 HIGH.
 
 ## 3. Technical Standards (POUR Framework)
@@ -108,6 +110,7 @@ Ao identificar um componente não mapeado ou de alta complexidade (ex: Gráficos
 
 ## 7. Verification Workflow (Definition of Done)
 *A conformidade deve ser verificada através destas etapas (Consulte o [**Report Template**](templates/REPORT.md) para detalhes de QA final e o [**Governance Guide**](references/guide-governance.md) para preparo de auditorias):*
+- [ ] **Artefatos Presentes:** o `REPORT.md` existe, está preenchido a partir do template e é mais recente que a última mudança de interface. Se houver desvio aceito, o `EXCEPTIONS.md` existe. Todos os artefatos do projeto versionados, nunca no `.gitignore`.
 - [ ] **Technical Check:** Código limpo, testável via linter integrado (`eslint-plugin-jsx-a11y` ou similar) e passando sem violações críticas por motores como `Axe`.
 - [ ] **Tab Order:** Caminho da tecla `Tab` validado manualmente (Garante a ausência de dead-ends no frontend).
 - [ ] **User Flow:** Interações dinâmicas (SPAs) testadas quanto aos feedbacks via `aria-live` em cenários de erro e sucesso sem uso do mouse.
@@ -115,10 +118,12 @@ Ao identificar um componente não mapeado ou de alta complexidade (ex: Gráficos
 - [ ] **Color & Perception:** Sem perda funcional ao perder o uso exclusivo das cores (simuladores de deficiência de visão).
 - [ ] **Auditoria de Exceções:** `EXCEPTIONS.md` revisado — toda entrada ativa tem dono do risco, aprovador, issue de rastreio e expiração; nenhuma entrada vencida sem tratamento.
 
+> **Agentes sem navegador.** Vários checkpoints acima exigem uma pessoa com navegador ou tecnologia assistiva. Um agente headless **MUST** gerar o `REPORT.md` mesmo assim, marcando esses itens com `[ ]`, escrevendo o motivo e nomeando quem deve executá-los. Relatório parcial e honesto é evidência; relatório ausente não é. A IA **MUST NOT** marcar como verificado qualquer item cuja evidência não consiga reproduzir.
+
 ---
 ### 📚 Biblioteca de Referências e Modelos
 **Guias Técnicos:** [Imagens](references/guide-images.md) | [Formulários](references/guide-forms.md) | [Botões](references/guide-buttons.md) | [Modals](references/guide-modals.md) | [Navegação](references/guide-navigation.md) | [Conteúdo](references/guide-content-interaction.md) | [Percepção Visual](references/guide-visual-perception.md) | [Tabelas](references/guide-tables.md) | [Tabs & Accordions](references/guide-tabs-accordion.md) | [Tooltips & Popovers](references/guide-tooltips-popovers.md) | [Toasts & Notificações](references/guide-toasts-notifications.md) | [Autocomplete](references/guide-autocomplete.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Drag & Drop](references/guide-drag-drop.md) | [Infinite Scroll](references/guide-infinite-scroll.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Responsivo & Zoom](references/guide-responsive-mobile.md) | [Framework Mapping](references/guide-framework-mapping.md) | [Platform-Native Mapping](references/guide-platform-native.md) | [Perfis de Conformidade](references/guide-compliance-profiles.md) | [Governança](references/guide-governance.md)
 
 **Padrões Externos:** [WAI-ARIA APG](https://www.w3.org/WAI/ARIA/apg/) | [eBay MIND Patterns](https://ebay.github.io/mindpatterns/) | [Deque Axe Core](https://github.com/dequelabs/axe-core)
 
-**Templates Opcionais:** [Report de Acessibilidade](templates/REPORT.md) | [Registro de Exceções](templates/EXCEPTIONS.md) | [Registro de Decisões](templates/A11Y-DECISIONS.md)
+**Artefatos do Projeto** *(versionados, não opcionais — ver Seções 2 e 7):* [Report de Acessibilidade](templates/REPORT.md) · antes de cada entrega | [Registro de Exceções](templates/EXCEPTIONS.md) · sempre que um desvio for aceito | [Registro de Decisões](templates/A11Y-DECISIONS.md) · a cada escolha entre alternativas conformes

--- a/docs/pt-BR/references/guide-governance.md
+++ b/docs/pt-BR/references/guide-governance.md
@@ -2,6 +2,16 @@
 
 > Escopo: Verificação estática, estratégia VPAT, conformidade ADA/EAA, EN 301 549 e prontidão para auditoria externa.
 
+## 0. Onde uma regra deve morar (princípio de projeto deste padrão)
+
+> **Evidência de campo (01/08/2026):** num post-mortem documentado de um projeto real, um agente aplicou corretamente as Seções 0 a 6 e não produziu nenhum `REPORT.md` nem `EXCEPTIONS.md`. O artefato que *foi* produzido (`A11Y-DECISIONS.md`) era o único citado pelo nome dentro de uma regra do **AI Behavior Contract**. A variável não foi obrigatoriedade — os outros dois já eram MUST em outros pontos — foi **onde o nome do arquivo aparecia**.
+
+Agentes tratam a Seção 2 como contrato executável e todo o resto como material de consulta. Portanto, ao estender este padrão:
+
+- **Tudo que a IA precisa FAZER** — criar um arquivo, recusar uma ação, checar algo antes de prosseguir — pertence ao **AI Behavior Contract (Seção 2)**, com um evento-gatilho explícito.
+- **A Seção 7 e os guias de referência** carregam profundidade, detalhe de verificação e justificativa — eles explicam e ampliam, mas nunca devem ser o *único* lugar onde uma obrigação existe.
+- Prefira **gatilhos por evento** ("antes de qualquer entrega ao usuário final") a **gatilhos por fase** ("na entrega final"): projetos de entrega contínua nunca alcançam a fase, e a regra nunca dispara.
+
 ## 1. Verificação Estática (O Mínimo de Engenharia)
 A verificação primária não consiste em ditar regras rígidas em uma *pipeline específica*, mas responsabilizar o ambiente de desenvolvimento (Seja o Dev ou a IA rodando em tempo real) por testes estáticos de validação rápida.
 - **Padrão de Código:** O código *deve* passar obrigatoriamente pelas checagens de linters ou avaliadores focados em acessibilidade (como `eslint-plugin-jsx-a11y` ou motor `axe`) sem exibir violações do nível crítico/sério antes da consolidação de código. 

--- a/docs/pt-BR/references/guide-governance.md
+++ b/docs/pt-BR/references/guide-governance.md
@@ -31,7 +31,8 @@ Ao criar widgets complexos customizados, o desenvolvedor (ou a IA) MUST incluir 
 Para preparar sub-sistemas para certificação externa e auditoria:
 1. **Inventory:** Consolidar uma lista ou storybook dos componentes visuais chaves do fluxo e seus comportamentos com tecnologias assistivas.
 2. **Keyboard Path:** Prevenir Dead-ends através do mapeamento claro e planejado da ordem do layout visual (`Tab`).
-3. **Auditoria Padrão:** Em caso de entrega final, o checklist em [**`templates/REPORT.md`**](../templates/REPORT.md) *deve* ser operado como "Definition of Done".
+3. **Auditoria Padrão:** O checklist em [**`templates/REPORT.md`**](../templates/REPORT.md) **MUST** ser operado como "Definition of Done" **antes de qualquer entrega ao usuário final** — build publicado, deploy, artefato compartilhado, tag — e não apenas numa "entrega final" que projetos de entrega contínua nunca alcançam (ver *Release Evidence*, `A11Y.md` §2).
+4. **Um relatório vivo, não um por publicação:** o relatório acompanha a **interface**, não a contagem de releases. Se nada mudou desde o último, ele continua valendo. Quando a interface muda, atualize a data e revisite apenas as entradas afetadas: todo checkpoint cuja evidência a mudança invalida volta para `[ ]` ou `[~]` até ser reverificado. Checkpoints humanos (leitor de tela, simulador de cor) mantêm o `[x]` e a data da sessão que os produziu, e são refeitos quando o fluxo que cobriam muda.
 
 ## 5. Relatórios e Responsabilidades (VPAT Strategy)
 Projetos que visam o mercado dos EUA devem ser compatíveis com a Seção 508:

--- a/docs/pt-BR/templates/REPORT.md
+++ b/docs/pt-BR/templates/REPORT.md
@@ -4,6 +4,12 @@ Este relatório compila as evidências de conformidade para uma determinada *Fea
 
 > Este relatório é um **registro versionado do projeto** — nunca adicione ao `.gitignore`. Evidência escondida do controle de versão não é evidência: QA e liderança verificam antes do release, e auditorias leem depois.
 
+> **Legenda de marcação (obrigatória):**
+> `[x]` verificado, com a evidência descrita ao lado · `[!]` verificado e **reprovado** (corrija, ou abra entrada no `EXCEPTIONS.md`) · `[~]` verificado parcialmente, com o que falta escrito · `[ ]` **não verificado** — o motivo MUST estar escrito ao lado.
+> Marcar `[x]` sem evidência reproduzível invalida o relatório inteiro.
+
+> **Agentes headless.** Uma IA sem navegador MUST gerar este relatório mesmo assim, marcando com `[ ]` todo checkpoint que exija navegador ou tecnologia assistiva, com o motivo e quem deve executá-lo. Relatório parcial e honesto é evidência; relatório ausente não é. O status geral é CONDICIONAL — nunca PASS — enquanto restar qualquer `[ ]` ou `[!]`.
+
 ---
 
 ## 📌 Contexto da Validação

--- a/docs/pt-BR/templates/REPORT.md
+++ b/docs/pt-BR/templates/REPORT.md
@@ -14,7 +14,8 @@ Este relatório compila as evidências de conformidade para uma determinada *Fea
 
 ## 📌 Contexto da Validação
 - **Funcionalidade/Épico:** [Ex: Checkout Integrado]
-- **Data do Teste:** [DD/MM/AAAA]
+- **Cobre a interface em:** [commit / build / versão contra a qual este relatório foi verificado]
+- **Data do Teste:** [DD/MM/AAAA — a data desta revisão; atualize sempre que a interface mudar]
 - **Status de Conformidade:** [✅ PASS | ⚠️ CONDICIONAL (Passa com Exceções) | 🚫 FAIL]
 
 ## 1. Verificação Técnica (Automated & Semantics)

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,43 @@
+# tools/
+
+Two dependency-free Python scripts. Both are **optional** — the standard works in a purely conversational flow — but a gate that fails a build is stronger than a rule an agent has to remember.
+
+> **Neither script establishes conformance.** Automated tooling detects only a fraction of real barriers. These check what a regex and a date comparison can check; the human checkpoints in `REPORT.md` are what establish the rest.
+
+---
+
+## `verify-a11y.py` — for projects adopting the standard
+
+```bash
+python3 verify-a11y.py [PROJECT_DIR] [--src SUBDIR] [--warn-only]
+```
+
+| Check | What it catches |
+|---|---|
+| `artifacts` | `REPORT.md` missing before a delivery (Release Evidence, §2) |
+| `freshness` | report older than the last interface change (git history, falling back to mtime) |
+| `report-status` | report claiming PASS while carrying `[ ]`, `[~]` or `[!]` checkpoints |
+| `exceptions` | entries without risk owner, approver, tracking issue or expiry — and expired ones |
+| `gitignore` | project artifacts excluded from version control |
+| `clickable-div` · `positive-tabindex` · `outline-none` · `aria-soup` | source anti-patterns from §6 |
+
+Exit code is `1` on errors, `0` on warnings only. Use `--warn-only` to report without failing the build while a team adopts the standard.
+
+**GitHub Actions:**
+
+```yaml
+- name: A11Y.md static gate
+  run: |
+    curl -sO https://raw.githubusercontent.com/fecarrico/A11Y.md/main/tools/verify-a11y.py
+    python3 verify-a11y.py . --src src
+```
+
+## `lint-standard.py` — for maintaining the standard itself
+
+```bash
+python3 lint-standard.py [REPO_ROOT]
+```
+
+Checks parity between `docs/en` and `docs/pt-BR` (file list, headings, contract rule count), orphaned reference guides, broken relative links, phase triggers ("at final delivery") that never fire in continuous delivery, and any label calling the project artifacts optional.
+
+Every check exists because the corresponding defect actually shipped: the ten guides orphaned in 1.0.0, the "Optional Templates" label and the phase trigger that together caused the [2026-08-01 field failure](../CHANGELOG.md). Run against the release before 1.2.0, it reports all four.

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,15 @@
 
 Two dependency-free Python scripts. Both are **optional** — the standard works in a purely conversational flow — but a gate that fails a build is stronger than a rule an agent has to remember.
 
+> [!IMPORTANT]
+> **These scripts are not part of the standard.** `A11Y.md` is portable markdown: it must keep working for anyone whose agent can read a file, with no runtime installed. Nothing in the normative core requires running these — and nothing ever should. They are a convenience for teams that want CI enforcement.
+
+> [!WARNING]
+> **Experimental (v0).** First release, exercised against fixtures and this repository — not against a wide range of real projects. A false positive in your pipeline is worse than no gate at all, so start with `--warn-only`, and please [open an issue](https://github.com/fecarrico/A11Y.md/issues) for anything it gets wrong. Bug reports are the fastest way to make it trustworthy.
+
 > **Neither script establishes conformance.** Automated tooling detects only a fraction of real barriers. These check what a regex and a date comparison can check; the human checkpoints in `REPORT.md` are what establish the rest.
+
+**Requirements:** Python 3.9+, standard library only — no `pip install`, no `package.json`. Python is preinstalled on macOS, most Linux distributions and virtually every CI runner. A Node port may follow if adoption shows real friction; until then, this is a deliberate choice for zero dependencies over toolchain familiarity.
 
 ---
 
@@ -23,14 +31,16 @@ python3 verify-a11y.py [PROJECT_DIR] [--src SUBDIR] [--warn-only]
 
 Exit code is `1` on errors, `0` on warnings only. Use `--warn-only` to report without failing the build while a team adopts the standard.
 
-**GitHub Actions:**
+**GitHub Actions** — pin to a tag, never to `main`: this is executable code, and a moving branch is a supply-chain risk. Bump the tag deliberately, the same way you would any other dependency.
 
 ```yaml
 - name: A11Y.md static gate
   run: |
-    curl -sO https://raw.githubusercontent.com/fecarrico/A11Y.md/main/tools/verify-a11y.py
-    python3 verify-a11y.py . --src src
+    curl -sO https://raw.githubusercontent.com/fecarrico/A11Y.md/v1.2.0/tools/verify-a11y.py
+    python3 verify-a11y.py . --src src --warn-only   # drop --warn-only once the team is ready
 ```
+
+Vendoring the script into your repository is equally valid, and gives you a reviewable diff when you upgrade.
 
 ## `lint-standard.py` — for maintaining the standard itself
 

--- a/tools/lint-standard.py
+++ b/tools/lint-standard.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""
+lint-standard.py — integrity checks for the A11Y.md standard itself.
+
+Written after a field post-mortem in which an agent applied the standard for
+weeks and never produced two of its three artifacts. The cause was not a
+missing MUST: it was a MUST living outside the AI Behavior Contract, and an
+index label ("Optional Templates") contradicting the normative body. Those
+are defects a script can catch, so it should.
+
+Checks:
+  parity        docs/en and docs/pt-BR hold the same files, headings and rules
+  orphans       every references/guide-*.md is reachable from the core file
+  links         relative links in the core and templates resolve on disk
+  phase-trigger no rule fires on a project phase ("at final delivery") instead
+                of an event — continuous delivery never reaches a phase
+  optional      the project artifacts are not labelled optional anywhere
+
+Usage: python3 lint-standard.py [REPO_ROOT]
+Stdlib only, no dependencies.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+LANGS = ("en", "pt-BR")
+findings: list[tuple[str, str]] = []
+
+
+def fail(check: str, message: str) -> None:
+    findings.append((check, message))
+
+
+def core(root: Path, lang: str) -> Path:
+    return root / "docs" / lang / "A11Y.md"
+
+
+def check_parity(root: Path) -> None:
+    listings = {}
+    for lang in LANGS:
+        base = root / "docs" / lang
+        listings[lang] = {p.relative_to(base).as_posix() for p in base.rglob("*.md")}
+    only_en = listings["en"] - listings["pt-BR"]
+    only_pt = listings["pt-BR"] - listings["en"]
+    for name in sorted(only_en):
+        fail("parity", f"docs/en/{name} has no pt-BR counterpart")
+    for name in sorted(only_pt):
+        fail("parity", f"docs/pt-BR/{name} has no en counterpart")
+
+    counts = {}
+    for lang in LANGS:
+        text = core(root, lang).read_text(encoding="utf-8")
+        contract = re.search(r"## 2\..*?(?=\n## 3\.)", text, re.S)
+        counts[lang] = (
+            len(re.findall(r"^#{1,6} ", text, re.M)),
+            len(re.findall(r"^- \*\*", contract.group(0), re.M)) if contract else 0,
+        )
+    if counts["en"][0] != counts["pt-BR"][0]:
+        fail("parity", f"heading count differs: en={counts['en'][0]} pt-BR={counts['pt-BR'][0]}")
+    if counts["en"][1] != counts["pt-BR"][1]:
+        fail("parity", f"AI Behavior Contract rule count differs: "
+                       f"en={counts['en'][1]} pt-BR={counts['pt-BR'][1]}")
+
+
+def check_orphans(root: Path) -> None:
+    for lang in LANGS:
+        text = core(root, lang).read_text(encoding="utf-8")
+        linked = set(re.findall(r"guide-[a-z0-9-]+\.md", text))
+        on_disk = {p.name for p in (root / "docs" / lang / "references").glob("guide-*.md")}
+        for orphan in sorted(on_disk - linked):
+            fail("orphans", f"docs/{lang}/references/{orphan} is not linked from the core file — "
+                            f"lazy loading can never discover it")
+
+
+def check_links(root: Path) -> None:
+    for lang in LANGS:
+        base = root / "docs" / lang
+        for path in [core(root, lang)] + sorted(base.glob("templates/*.md")) + sorted(base.glob("references/*.md")):
+            text = path.read_text(encoding="utf-8")
+            for target in re.findall(r"\]\((?!https?:|#|mailto:)([^)]+)\)", text):
+                resolved = (path.parent / target.split("#")[0]).resolve()
+                if not resolved.exists():
+                    fail("links", f"{path.relative_to(root)} → broken relative link '{target}'")
+
+
+def check_phase_triggers(root: Path) -> None:
+    """Phase triggers never fire in continuously delivered projects."""
+    patterns = (
+        re.compile(r"(in case of|at|on|upon)\s+final\s+delivery", re.I),
+        re.compile(r"em caso de entrega final|na entrega final", re.I),
+        re.compile(r"(at|during)\s+(the\s+)?(final\s+)?QA cycle", re.I),
+        re.compile(r"no ciclo de QA", re.I),
+    )
+    for path in sorted((root / "docs").rglob("*.md")):
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            # the design principle in the governance guide quotes these on purpose
+            if "gatilhos por fase" in line or "phase triggers" in line:
+                continue
+            for pattern in patterns:
+                if pattern.search(line):
+                    fail("phase-trigger",
+                         f"{path.relative_to(root)}:{line_no} — rule fires on a project phase, not an event. "
+                         f"Use 'before any delivery to an end user' (see Release Evidence, §2).")
+
+
+def check_optional_label(root: Path) -> None:
+    for path in sorted((root / "docs").rglob("*.md")):
+        for line_no, line in enumerate(path.read_text(encoding="utf-8").splitlines(), 1):
+            if re.search(r"(Optional Templates|Templates Opcionais)", line):
+                fail("optional",
+                     f"{path.relative_to(root)}:{line_no} — project artifacts labelled optional while the "
+                     f"body requires them. This exact contradiction caused the 2026-08-01 field failure.")
+
+
+def main() -> int:
+    root = Path(sys.argv[1] if len(sys.argv) > 1 else ".").resolve()
+    if not core(root, "en").is_file():
+        print(f"error: {root} does not look like the A11Y.md repository", file=sys.stderr)
+        return 2
+
+    for check in (check_parity, check_orphans, check_links, check_phase_triggers, check_optional_label):
+        check(root)
+
+    for name, message in findings:
+        print(f"✗ [{name}] {message}")
+    print()
+    print(f"FAIL — {len(findings)} issue(s)." if findings else "PASS — standard is internally consistent.")
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/verify-a11y.py
+++ b/tools/verify-a11y.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+verify-a11y.py — static gate for projects adopting the A11Y.md standard.
+
+Checks what can be verified without a browser: that the project artifacts
+exist, are current and well-formed, and that the source is free of the
+anti-patterns a regex can catch. Exits non-zero when a check fails, so it
+can gate a build.
+
+It does NOT establish WCAG conformance. Automated tooling detects only a
+fraction of real barriers; the human checkpoints in REPORT.md remain the
+part that matters most. A clean run means "nothing statically detectable
+is wrong", not "this is accessible".
+
+Usage:
+    python3 verify-a11y.py [PROJECT_DIR] [--src SUBDIR] [--warn-only]
+
+Stdlib only, no dependencies.
+"""
+
+import argparse
+import datetime as dt
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ARTIFACTS = ("REPORT.md", "EXCEPTIONS.md", "A11Y-DECISIONS.md")
+SOURCE_SUFFIXES = {".html", ".htm", ".jsx", ".tsx", ".js", ".ts", ".vue", ".svelte", ".css", ".scss", ".astro"}
+SKIP_DIRS = {".git", "node_modules", "dist", "build", ".next", "out", "vendor", "__pycache__", ".venv"}
+
+# Placeholder text from the templates — an unfilled template is not an entry.
+PLACEHOLDER = re.compile(r"\[(YYYY|MM/DD|e\.g\.|Ex:|Who|Link|Date|Quem|Data)", re.I)
+
+findings: list[tuple[str, str, str]] = []  # (level, check, message)
+
+
+def fail(check: str, message: str) -> None:
+    findings.append(("ERROR", check, message))
+
+
+def warn(check: str, message: str) -> None:
+    findings.append(("WARN", check, message))
+
+
+def git(root: Path, *args: str) -> str | None:
+    try:
+        out = subprocess.run(["git", "-C", str(root), *args],
+                             capture_output=True, text=True, timeout=15)
+        return out.stdout.strip() if out.returncode == 0 else None
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
+def source_files(root: Path, src: Path):
+    for path in src.rglob("*"):
+        if path.is_file() and path.suffix.lower() in SOURCE_SUFFIXES:
+            if not any(part in SKIP_DIRS for part in path.relative_to(root).parts):
+                yield path
+
+
+# --- checks ----------------------------------------------------------------
+
+def check_artifacts_exist(root: Path) -> Path | None:
+    """REPORT.md is required. The other two are required only when their
+    triggering event has occurred, which this script cannot observe."""
+    report = root / "REPORT.md"
+    if not report.is_file():
+        fail("artifacts", "REPORT.md not found. Release Evidence (A11Y.md §2) requires it "
+                          "before any delivery to an end user — generate it from templates/REPORT.md.")
+        return None
+    return report
+
+
+def check_report_freshness(root: Path, report: Path, src: Path) -> None:
+    """The report must be newer than the last interface change."""
+    last_ui = git(root, "log", "-1", "--format=%cI", "--", str(src.relative_to(root)) if src != root else ".")
+    last_report = git(root, "log", "-1", "--format=%cI", "--", "REPORT.md")
+    if last_ui and last_report:
+        if last_report < last_ui:
+            fail("freshness", f"REPORT.md (last commit {last_report[:10]}) is older than the last "
+                              f"interface change ({last_ui[:10]}). Revisit the entries that change affects.")
+        return
+    # no git history available — fall back to mtime
+    newest = max((p.stat().st_mtime for p in source_files(root, src)), default=None)
+    if newest and report.stat().st_mtime < newest:
+        fail("freshness", "REPORT.md is older than the most recently modified source file.")
+
+
+def check_report_status(report: Path) -> None:
+    """A report claiming PASS cannot carry unverified or failed checkpoints."""
+    text = report.read_text(encoding="utf-8", errors="replace")
+    body = "\n".join(l for l in text.splitlines() if not l.lstrip().startswith(">"))
+    unchecked = len(re.findall(r"^\s*-\s*\[\s\]", body, re.M))
+    failed = len(re.findall(r"^\s*-\s*\[!\]", body, re.M))
+    partial = len(re.findall(r"^\s*-\s*\[~\]", body, re.M))
+    claims_pass = re.search(r"(Compliance Status|Status de Conformidade).*(✅|PASS)", text)
+    if claims_pass and not re.search(r"CONDITIONAL|CONDICIONAL", text):
+        if unchecked or failed or partial:
+            fail("report-status", f"REPORT.md claims PASS while carrying {unchecked} unverified, "
+                                  f"{partial} partial and {failed} failed checkpoints. "
+                                  f"Status must be CONDITIONAL until they are closed.")
+    if failed:
+        warn("report-status", f"{failed} checkpoint(s) marked [!] (verified and failed) — "
+                              f"fix them or open an EXCEPTIONS.md entry.")
+
+
+def check_exceptions(root: Path) -> None:
+    """Every exception needs owner, approver, tracking issue and a future expiry."""
+    path = root / "EXCEPTIONS.md"
+    if not path.is_file():
+        return  # only required once a deviation is accepted
+    text = path.read_text(encoding="utf-8", errors="replace")
+    blocks = re.split(r"^#{2,4}\s+\d+\.\s*(?:Basic Details|Detalhes Básicos)", text, flags=re.M)[1:]
+    today = dt.date.today()
+    for i, block in enumerate(blocks, 1):
+        entry_id = re.search(r"(?:Exception ID|ID da Exceção):\*{0,2}[ \t]*(.*)", block)
+        label = (entry_id.group(1).strip() if entry_id else f"entry #{i}")[:40]
+        if PLACEHOLDER.search(label) or not label:
+            continue  # unfilled blank copy from the template
+        for field, pattern in (("risk owner", r"(Risk Owner|Dono do Risco)"),
+                               ("approver", r"(Approved by|Aprovado por)"),
+                               ("tracking issue", r"(Tracking Issue|Issue de Rastreio)")):
+            m = re.search(pattern + r":\*{0,2}[ \t]*(.*)", block)
+            if not m or not m.group(2).strip() or PLACEHOLDER.search(m.group(2)):
+                fail("exceptions", f"{label}: missing {field}.")
+        expiry = re.search(r"(?:Expiry|Expiração)[^:\n]*:\*{0,2}[ \t]*\[?(\d{4}-\d{2}-\d{2})", block)
+        if not expiry:
+            fail("exceptions", f"{label}: missing or unparseable expiry date (use YYYY-MM-DD).")
+        else:
+            date = dt.date.fromisoformat(expiry.group(1))
+            if date < today:
+                fail("exceptions", f"{label}: expired on {date} — review, fix or consciously renew it.")
+            elif (date - today).days <= 14:
+                warn("exceptions", f"{label}: expires in {(date - today).days} day(s).")
+
+
+def check_gitignore(root: Path) -> None:
+    """Artifacts are versioned records; hiding them defeats their purpose."""
+    gitignore = root / ".gitignore"
+    if not gitignore.is_file():
+        return
+    patterns = [l.strip() for l in gitignore.read_text(encoding="utf-8", errors="replace").splitlines()
+                if l.strip() and not l.startswith("#")]
+    for artifact in ARTIFACTS:
+        for pattern in patterns:
+            if pattern.strip("/") == artifact or pattern in ("*.md", "**/*.md"):
+                fail("gitignore", f"{artifact} is excluded by .gitignore rule '{pattern}'. "
+                                  f"Project artifacts must be versioned.")
+                break
+
+
+def check_source_antipatterns(root: Path, src: Path) -> None:
+    checks = (
+        ("clickable-div", re.compile(r"<(div|span)\b[^>]*\bon[cC]lick\b"),
+         "clickable <div>/<span> — use a native <button> (A11Y.md §6)"),
+        ("positive-tabindex", re.compile(r"tabindex\s*=\s*[\"']?\s*[1-9]"),
+         "positive tabindex breaks the natural focus order"),
+        ("outline-none", re.compile(r"outline\s*:\s*(none|0)\s*[;}]"),
+         "outline:none — provide a visible focus indicator instead (SC 2.4.7)"),
+        ("aria-soup", re.compile(r"<button\b[^>]*\brole\s*=\s*[\"']button[\"']|<a\b[^>]*\brole\s*=\s*[\"']link[\"']"),
+         "redundant role on a native element (ARIA Soup, A11Y.md §6)"),
+    )
+    for path in source_files(root, src):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for line_no, line in enumerate(text.splitlines(), 1):
+            for name, pattern, message in checks:
+                if pattern.search(line):
+                    rel = path.relative_to(root)
+                    level = warn if name == "outline-none" else fail
+                    level(name, f"{rel}:{line_no} — {message}")
+
+
+# --- main ------------------------------------------------------------------
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("project", nargs="?", default=".", help="project root (default: current directory)")
+    parser.add_argument("--src", default=None, help="subdirectory holding the interface source (default: project root)")
+    parser.add_argument("--warn-only", action="store_true", help="always exit 0, printing findings only")
+    args = parser.parse_args()
+
+    root = Path(args.project).resolve()
+    if not root.is_dir():
+        print(f"error: {root} is not a directory", file=sys.stderr)
+        return 2
+    src = (root / args.src).resolve() if args.src else root
+
+    report = check_artifacts_exist(root)
+    if report:
+        check_report_freshness(root, report, src)
+        check_report_status(report)
+    check_exceptions(root)
+    check_gitignore(root)
+    check_source_antipatterns(root, src)
+
+    errors = [f for f in findings if f[0] == "ERROR"]
+    warnings = [f for f in findings if f[0] == "WARN"]
+    for level, check, message in errors + warnings:
+        marker = "✗" if level == "ERROR" else "!"
+        print(f"{marker} [{check}] {message}")
+
+    print()
+    if errors:
+        print(f"FAIL — {len(errors)} error(s), {len(warnings)} warning(s).")
+    elif warnings:
+        print(f"PASS with {len(warnings)} warning(s).")
+    else:
+        print("PASS — nothing statically detectable is wrong.")
+    print("This is not a conformance claim: the human checkpoints in REPORT.md are what establish it.")
+
+    return 1 if errors and not args.warn_only else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What happened

An agent applied A11Y.md v1.1.0 to a real project for weeks. It followed Sections 0–6 well — no clickable divs, no unnamed controls, focus managed across routing, nothing depending on hue alone — generated and maintained `A11Y-DECISIONS.md`, and **never produced a `REPORT.md` or an `EXCEPTIONS.md`**. It then wrote a [post-mortem](https://github.com/fecarrico/A11Y.md/wiki/Evidence-and-Research) of its own failure.

The diagnosis is verifiable in the document itself, independent of the agent's self-report:

| Artifact | Where it was named | Outcome |
|---|---|---|
| `A11Y-DECISIONS.md` | inside a rule of the **AI Behavior Contract** (§2) | **created and maintained** |
| `EXCEPTIONS.md` | §2 only conditionally, for *reading* in review mode; plus §7 and the governance guide | never created |
| `REPORT.md` | §7 and the governance guide only | never created |

Obligation was not the variable — the body said MUST four times about these files. **Placement and trigger were.** Agents treat §2 as an executable contract and everything else as reference material.

## What changes

**Two new contract rules (11 → 13):**
- **Exception Memory** — accepting a WCAG SC violation creates or updates `EXCEPTIONS.md` *in the same turn*, from the template, with risk owner, approver, tracking issue and expiry. An accepted-but-unrecorded exception is a contract violation, not a pending decision.
- **Release Evidence** — before any delivery to an end user (build, deploy, shared artifact, tag), verify a `REPORT.md` newer than the last interface change, or state explicitly that the delivery carries no conformance evidence. This is an **event** trigger: the old phase trigger ("final delivery or QA cycle") never fires in a continuously delivered project.

**Three defects closed:**
- `templates/` was swept up by Lazy Context Loading. It is now explicitly excluded: `references/` is *per-component* context, `templates/` is *lifecycle* context. Adds **template fidelity** — artifacts are created from the template files, never deduced from prose.
- **"Optional Templates" → "Project Artifacts"** (versioned, not optional), each with its trigger. The index label contradicted a normative body that says MUST four times.
- The Verification Workflow verified the interface but never that evidence of it exists. **Artifacts Present** is now its first checkpoint.

**Anti-fabrication, for the agents that actually run this:**
- **Headless-agent clause** — most agents applying this standard have no browser. The vacuum pushed toward two bad exits: mark everything (fraud) or produce nothing (what happened). Now: produce the report, mark the unverifiable checkpoints, name who must run them.
- **Marking legend in `REPORT.md`** — `[x]` verified with evidence · `[!]` verified and failed · `[~]` partial · `[ ]` not verified, reason required. An empty checkbox was ambiguous, and ambiguity rewards marking what "is probably fine".

**And a design principle,** so this defect is not recreated: anything the AI must *do* belongs in the behavior contract with an explicit event trigger; guides carry depth, never sole obligation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Plus: the executable gate (post-mortem item 3.7)

*"Prose depends on reading, and reading fails — this document is the proof."* Two dependency-free Python scripts in `tools/`, both **optional**:

- **`verify-a11y.py`** (for adopters) — artifact presence and freshness, report-status honesty (no PASS while `[ ]`/`[~]`/`[!]` remain), exception fields and expiry, gitignored artifacts, and the source anti-patterns a regex can catch, including ARIA Soup. Non-zero exit on errors; `--warn-only` while a team adopts.
- **`lint-standard.py`** (for this repository) — en/pt-BR parity, orphaned guides, broken links, phase triggers, and any "optional" label on the project artifacts.

They ship in this PR rather than a separate one because they depend on it: run `lint-standard.py` against the release *before* these doc fixes and it reports exactly the four defects that caused the field failure —

```
✗ [phase-trigger] docs/{en,pt-BR}/references/guide-governance.md:24 — rule fires on a project phase, not an event.
✗ [optional]      docs/{en,pt-BR}/A11Y.md:124 — project artifacts labelled optional while the body requires them.
FAIL — 4 issue(s).
```

— and against this branch: `PASS — standard is internally consistent.`

**Verification:** both were exercised against fixtures, not just typechecked. That run surfaced a real bug in the exception parser (`\s*` crossing a newline, so an empty **Approved by** field silently captured the next line and passed) — fixed and re-tested. A deliberately broken fixture reports 6 errors and 2 warnings; repaired, it passes; touching a source file afterwards correctly re-fails on `freshness`.
