### PR TITLE
docs: name the category — a constraint, not a capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 > **A11Y.md is not a guideline.**
 > It is an accessibility validation protocol and a **persistent context architecture** for developing accessible software with AI. It is designed to integrate with AI agent systems (Cursor, Claude, Copilot) to ensure certifiable compliance from genesis.
+>
+> Most agent context teaches a **capability** — how to do something, loaded when the task calls for it. This one defines a **constraint**: what may never be done, whatever you are building. That is why it belongs in context *before* the agent knows what it is about to build. *([the argument in full](https://dev.to/fecarrico/not-every-skill-is-a-capability-43n9) · [taken to the Agent Skills spec](https://github.com/agentskills/agentskills/discussions/484))*
 
 We treat `.gitignore`, `eslint`, and `CLAUDE.md` as canonical truths in our repositories. But why isn't accessibility canonical? `A11Y.md` translates accessibility rules into a portable governance layer: a **platform-agnostic normative core** (POUR, compliance profiles, severity, governance) with **mature web references** and a **native translation layer** (iOS, Android, React Native, Flutter). Instead of generic coding advice, it forces any coding agent to strictly adhere to WCAG 2.2 AA and ADA standards from the very first line of generated UI code.
 

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -22,6 +22,8 @@
 
 > **O A11Y.md não é um guia de boas práticas.**
 > Ele é um protocolo de validação de acessibilidade e uma **arquitetura de contexto persistente** para o desenvolvimento de softwares guiado por IA. Foi concebido para integrar-se com agentes autônomos (Cursor, Claude, Copilot) garantindo conformidade certificável desde a origem.
+>
+> A maior parte do contexto para agentes ensina uma **capacidade** — como fazer algo, carregada quando a tarefa pede. Este define uma **restrição**: o que não pode ser feito, seja lá o que você esteja construindo. É por isso que ele precisa estar em contexto *antes* de o agente saber o que vai construir. *([o argumento completo](https://dev.to/fecarrico/not-every-skill-is-a-capability-43n9) · [levado à especificação do Agent Skills](https://github.com/agentskills/agentskills/discussions/484))*
 
 Nós tratamos arquivos como `.gitignore`, `eslint` e `CLAUDE.md` como verdades canônicas nos nossos repositórios. Mas por que a acessibilidade não é canônica? O `A11Y.md` traduz as regras de acessibilidade para uma camada de governança portátil: um **núcleo normativo agnóstico de plataforma** (POUR, perfis de conformidade, severidade, governança) com **referências web maduras** e uma **camada de tradução nativa** (iOS, Android, React Native, Flutter). Em vez de regras genéricas, ele força qualquer agente a aderir estritamente às normas WCAG 2.2 AA e ADA desde a primeira linha de código gerada.
 


### PR DESCRIPTION
The framing block already said what A11Y.md **is not** (a guideline) and what it **is** (a protocol, a persistent context architecture). It never said what *kind of thing* it is — and that turned out to be the sharpest available framing:

> Most agent context teaches a **capability** — how to do something, loaded when the task calls for it. This one defines a **constraint**: what may never be done, whatever you are building. That is why it belongs in context *before* the agent knows what it is about to build.

Two sentences, in both languages, in the paragraph every visitor reads. The tagline is untouched — ten outlets have quoted it verbatim, and consistency there is worth more than precision.

The distinction now has a citable source instead of living only in this README: the [published argument](https://dev.to/fecarrico/not-every-skill-is-a-capability-43n9) and the [proposal taken to the Agent Skills spec](https://github.com/agentskills/agentskills/discussions/484), where the ecosystem's own evidence is laid out — every client extension so far moves activation in the restrictive direction, and Cursor's migration tool refuses to convert always-apply rules.

`lint-standard.py` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)