### PR TITLE
chore(benchmark): keep collected data out of the repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,13 @@ WIKI/
 # benchmark: vendored engine and generated manifest (the lock and results are committed)
 benchmark/harness/axe.min.js
 benchmark/runs/manifest.json
+
+# benchmark: collected data never enters this repository. Generations and raw API
+# responses are research data — published as a dataset with its own DOI, where they
+# are citable and where their size is not this repo's problem. What belongs here is
+# the protocol, the scripts, and aggregated results (put those in benchmark/results/,
+# which is deliberately not ignored).
+benchmark/.env
+benchmark/runs/
+
 __pycache__/


### PR DESCRIPTION
A run of the pre-registered design is 54 generations; the design the methodology is growing into is an order of magnitude past that. Either way, generated pages and raw API responses are research data, not part of the standard — they belong in a dataset with its own DOI, where they are citable and where their size is nobody's problem here.

Ignores `benchmark/runs/` wholesale rather than by file type, so a new output directory cannot leak in later. Aggregated results stay versionable under `benchmark/results/`, which is deliberately not ignored. Also ignores `benchmark/.env`, where the collector reads its API key.

Nine added lines, no removals.

---

Replaces #31, which was cut before #29 and #30 were squash-merged: because squashing rewrites the commits, that branch no longer recognised them as applied, and merging it would have **deleted `tools/context-cost.py` and reverted `tools/README.md`**. This branch is rebased on current `main` and carries only the `.gitignore` change that was still missing.