### PR TITLE
Benchmark v2 — the experiment the pilot demanded

### DIFF
--- a/benchmark/CONTROL.md
+++ b/benchmark/CONTROL.md
@@ -1,0 +1,28 @@
+# The control standard — construction notes
+
+`control-standard/` is condition C of the pre-registered design ([`METHODOLOGY.md`](METHODOLOGY.md)): the placebo. It exists to answer one objection — *"the improvement comes from having any long, well-organised technical standard in context, not from what A11Y.md says"* — and it can only answer it if it matches the real standard in everything except subject. This file documents how that matching was done, so the control can be audited and rebuilt. It lives outside `control-standard/` on purpose: the model's `read_file` tool is scoped to that directory, and these notes must never be readable by the subject of the experiment.
+
+## Construction rules
+
+1. **Subject swap, shape kept.** The control is a frontend *performance* standard (Core Web Vitals, budgets, rendering cost). Its core mirrors `docs/en/A11Y.md` section for section: a Principle Zero, three profiles, a severity model, an AI behavior contract, a §2.1 lazy-loading map, a four-letter technical framework, anti-patterns, a verification workflow, and the same three lifecycle templates (report, exceptions, decisions).
+2. **Same mechanics, same invocation.** Same `references/` + `templates/` layout, same trigger-map table format, same MUST/severity language, and a grounding sentence that is condition D's sentence with the subject swapped (see `collect.py`). If the control were a single flat document, condition C would have one read round-trip where D has several — and the comparison would measure process shape, not content.
+3. **Size parity within ~5% per task.** Parity is measured as core + the guide(s) the §2.1 map selects for each benchmark task, not core alone. Measured at construction (chars, `docs/en` vs `control-standard`):
+
+   | Load | delta |
+   |---|---|
+   | core alone | −3.5% |
+   | per task (10 tasks) | −3.2% … −5.4% |
+
+   The control runs consistently *slightly lighter*. Direction of bias: a lighter placebo makes any "long document effect" marginally weaker in C, which marginally favors D in the D−C contrast. It is declared here rather than hidden; anyone tightening the parity further should add performance content, never padding.
+4. **Zero accessibility content.** No accessibility vocabulary, no assistive-technology concepts, no `alt`, no semantics-as-accessibility framing — verified by word-boundary sweep (`grep -rinwE "accessibility|accessible|aria|a11y|wcag|screen readers?|alt|focus|keyboard|contrast|semantics?"`). The control must be *silent* on the subject, not prescriptive in either direction: even an `alt=""` in a code example teaches something the placebo must not teach.
+5. **Content must be real.** The performance guidance is meant to be sound — a model that follows it should produce genuinely faster pages. A placebo of plausible-looking nonsense would be detectable by the model and would test "good standard vs bad standard" instead of "this subject vs another subject".
+6. **Guide-for-guide pairing on the benchmark tasks only.** The control has 11 guides — the ones the 10 tasks can trigger — not counterparts for all 29 of the real standard's guides. The §2.1 asymmetry beyond those rows (e.g. A11Y.md's cognitive guide, which its core text pulls into form tasks) is part of what is being measured: the standards legitimately differ in what they tell the agent to load, and the loading-behaviour outcome records it.
+
+## Known asymmetries (declared)
+
+- The real standard's core can instruct loading files outside the task's map row (the pilot showed `guide-cognitive.md` pulled into a form task by a core rule). The control's core has no equivalent cross-pull; its per-task load is more predictable. This shows up in the loading-behaviour outcome, where it belongs.
+- The real standard is public and may be in training data; the control was written for this benchmark and cannot be. This asymmetry favors *the control being followed less fluently* and is listed in the methodology's limitations.
+
+## Maintenance
+
+The control is frozen with the protocol. If `docs/en/A11Y.md` changes enough to move parity beyond the declared tolerance, the control is re-paired **before** the next collection wave and the change is logged in `DEVIATIONS.md`; it is never touched mid-wave.

--- a/benchmark/METHODOLOGY.md
+++ b/benchmark/METHODOLOGY.md
@@ -1,55 +1,158 @@
 # A11Y.md Efficacy Benchmark — Pre-registered Methodology
 
-> **Status:** Pre-registered — this protocol is published **before any data collection**. Results will be reported against it exactly; any deviation will be documented, not hidden.
-> **Version:** 1.0 · 2026-07-25 · Felipe A. Carriço
+> **Status:** Pre-registered, version 2.0 — published **before any data collection**. Results will be reported against this protocol exactly; any deviation will be documented in `DEVIATIONS.md`, never hidden.
+> **Version:** 2.0 · 2026-08-16 · Felipe A. Carriço
+> **Supersedes:** v1.0 (2026-07-25, commit `eb6f28f`). No data was collected under v1. One pilot generation was run under a draft of the v2 harness and discarded; see *Pilot disclosure*.
 
-## The claim under test
+## Version history
 
-> Injecting `A11Y.md` as persistent context reduces **automatically detectable accessibility violations** in AI-generated UI code.
+| Version | Date | What changed and why |
+|---|---|---|
+| 1.0 | 2026-07-25 | Initial pre-registration: 3 models × 3 tasks × 2 conditions × 3 runs, collected by hand in consumer chat interfaces, full core pasted into the prompt. |
+| 2.0 | 2026-08-16 | Redesigned before collection. (a) **The v1 design did not test the standard as it works**: pasting the full core defeats lazy loading, which is the standard's declared architecture. Collection now gives the model a scoped `read_file` tool and lets the mechanism run. (b) **Two active control conditions added** — a one-line accessibility request and a size-and-mechanics-matched placebo standard — because "standard vs nothing" cannot separate the standard's content from cheaper ways of getting the same effect. (c) **Token accounting added as a co-primary outcome.** (d) Collection moved from hand-driven chat interfaces to API calls: reproducible, isolated by construction, and free-tier viable. (e) Blinding and a pre-specified analysis plan added. |
 
-This benchmark makes **no claim about full accessibility or real assistive-technology usability**. Automated tooling detects only a fraction of real-world barriers (published estimates range ~30–57%). Human validation with assistive-technology users is Phase 2 — separate, and separately pre-registered.
+## The claims under test
+
+1. **Efficacy:** giving the AI the A11Y.md standard reduces automatically detectable accessibility violations in generated UI code — *and reduces them more than cheaper alternatives* (a generic "make it accessible" request; an equally long, equally structured document about a different subject).
+2. **Cost:** the standard's lazy-loading architecture keeps its context cost bounded and task-proportional — the model loads the core plus the guides the task calls for, not the whole library — at a measurable token cost per task.
+
+This benchmark makes **no claim about full accessibility or real assistive-technology usability**. Automated tooling detects only a fraction of real-world barriers (published estimates range ~30–57%). Human validation is Phase 2 — separate, and separately pre-registered.
 
 ## Design
 
-- **Models (3):** Claude, Gemini Pro, GPT — consumer chat interfaces, default settings, fresh session per run, model/version recorded at run time.
-- **Tasks (3):** canonical components where the WebAIM Million's recurring error categories concentrate:
-  1. **Signup form** with inline validation and error messaging.
-  2. **Destructive-confirmation modal** opened from an item list.
-  3. **Sortable data table** with a per-row action.
-- **Conditions (2):**
-  - **A — bare:** the task prompt alone.
-  - **B — grounded:** the identical prompt preceded by the full `docs/en/A11Y.md` (v1.1.0+, Standard profile). No other wording differences.
-- **Repetitions:** 3 per cell → 3 models × 3 tasks × 2 conditions × 3 runs = **54 generations**.
-- **Prompts:** fixed verbatim in [`PROMPTS.md`](PROMPTS.md), published before data collection. The prompts never mention accessibility — that is the point.
+### Conditions (4)
+
+The task prompt is identical across conditions; only what precedes it differs. Preambles are fixed verbatim here.
+
+| | Condition | Preamble (verbatim) | Documents available |
+|---|---|---|---|
+| A | bare | *(none)* | none |
+| B | generic | `Make it accessible.` | none |
+| C | control | `When developing the frontend, follow strictly the performance rules defined in PERF.md. Read it with the read_file tool at 'PERF.md'.` | placebo standard (`benchmark/control-standard/`) |
+| D | a11ymd | `When developing the frontend, follow strictly the accessibility rules defined in A11Y.md. Read it with the read_file tool at 'A11Y.md'.` | `docs/en/` (core + references + templates) |
+
+Condition D's sentence is the standard's own Quick Start invocation, verbatim, with one harness concession: naming the tool, which the model cannot otherwise discover. **Nothing else is added** — no hint that reference files exist, no instruction to load selectively. Lazy loading must emerge from reading the core, or the benchmark is teaching the behaviour it claims to measure.
+
+Condition C is the placebo: a performance standard with the **same size, the same shape, and the same mechanics** — a core file with a loading-triggers map, per-component guides, the same tool. It isolates the effect of the A11Y.md's *content* from the effect of having any long, well-organised technical standard in context. Its sentence is D's sentence with the subject swapped; if it mentioned accessibility it would cue the very thing it exists to rule out.
+
+The three pre-registered contrasts: **D−B** (does the standard beat one free sentence? — the question that decides whether the project has a reason to exist), **D−C** (does the content beat the form?), **D−A** (headline effect).
+
+### Lazy loading, reproduced faithfully
+
+A raw API call has no filesystem, so pasting is the only way to supply documents — and pasting everything kills the mechanism while pasting the core alone strands it. The collector therefore exposes **one tool, `read_file`**, scoped to the condition's document directory (path traversal and absolute paths are refused). The model reads the core, consults the §2.1 loading map, and requests what it decides to request. Every file request is logged with its size; the request pattern is itself a pre-registered outcome (see *Loading behaviour*).
+
+One generation = one conversation, from scratch. No memory, no accumulated context across generations. Via API this is the default; no discipline required.
+
+### Arms
+
+| Arm | Engine | Role | Cost |
+|---|---|---|---|
+| 1 — primary | **Gemini API, free tier** (current Flash-class model; exact model string and version recorded per call) | The full factorial design below. All confirmatory analysis runs on this arm. | $0 |
+| 1-ext — extension | Claude API / OpenAI API | **Pre-registered, conditional:** the identical protocol runs on additional models if and when usable API credits exist. Extension arms replicate; they do not alter the design. Each extension arm is reported separately, never pooled with Arm 1. | conditional |
+| 2 — ecological | **Claude Code CLI** (official client, subscription) | A small-n check that the Arm 1 effect direction survives in a real coding agent with a real filesystem: conditions A and D only, a task subset, `n=3`. Reported descriptively; no hypothesis test. | $0 marginal |
+
+Arm 1 is the study. It is honest about what it is: one model family, named in the title of any report. A single-model study with active controls and a frozen protocol outranks a three-model study with neither; the extension arms exist so that more models require no protocol change, only funding.
+
+### Tasks (10)
+
+Drawn from the WebAIM Million's recurring error categories plus the ARIA-redundancy pattern this repository documents. Prompts are frozen verbatim in [`PROMPTS.md`](PROMPTS.md) and never mention accessibility. Each task maps to the reference guide(s) the standard's §2.1 loading map would select — the pre-registered expectation for the loading-behaviour outcome:
+
+| # | Task | Expected guide(s) per §2.1 |
+|---|---|---|
+| 1 | Signup form with inline validation | `guide-forms` |
+| 2 | Destructive-confirmation modal | `guide-modals` |
+| 3 | Sortable data table | `guide-tables` |
+| 4 | Site navigation with dropdown submenus | `guide-navigation` |
+| 5 | File upload with progress and failure states | `guide-forms`, `guide-loading-skeleton` |
+| 6 | Auto-advancing image carousel | `guide-carousels-sliders` |
+| 7 | Search box with live suggestions | `guide-autocomplete` |
+| 8 | Product card grid | `guide-images`, `guide-buttons` |
+| 9 | Async save with toast notifications | `guide-toasts-notifications` |
+| 10 | Dashboard chart with table toggle | `guide-charts`, `guide-tables` |
+
+The set deliberately spans cheap guides (~400 chars) to heavy ones (~7,700 chars), so the token outcome has range.
+
+### Size
+
+**10 tasks × 4 conditions × 10 repetitions = 400 generations** (Arm 1). Free-tier daily caps make this a multi-day collection: waves are collected on consecutive days with conditions interleaved (never one condition's block on one day — interface drift must not load onto a condition), resumable without re-running anything already on disk. Collection dates, model version strings, and per-call token usage are logged per generation.
 
 ## Measurement
 
-1. **axe-core (pinned version)** over each output mounted unmodified in a static harness page — violations counted by impact (critical / serious / moderate / minor).
-2. **Deterministic per-task checklist**, verified by script against the rendered DOM:
-   - native `<button>`/`<a>` vs clickable `div`
-   - labels programmatically associated to inputs
-   - modal: focus moved in, contained, and returned on close; `Escape` closes
-   - dynamic feedback exposed through a live region (`role="status"`/`role="alert"`/`aria-live`)
-   - minimum 24×24 CSS px target size (SC 2.5.8)
-   - no redundant ARIA on native elements (ARIA Soup check)
-3. **Secondary:** prompt+context token footprint per condition; whether the model asked for or needed reference guides.
+### Violations (co-primary)
 
-## Analysis
+1. **axe-core, pinned version, SHA-256-verified** (already vendored in `harness/`), over each generated page mounted unmodified. Primary count: violations of impact `critical` + `serious` per generation.
+2. **Deterministic per-task checklist** (harness), each item mapped to a WCAG success criterion and a WebAIM Million category — published as a table so the checklist is auditable against external sources, not against the standard it measures.
+3. **Second engine, robustness only:** a second independent scanner (IBM Equal Access or Pa11y, version pinned at the moment it is added, before any unblinding) runs over the same files. Agreement between engines is reported; disagreement is reported, not resolved by choosing the friendlier engine.
+4. **Items the harness marks MANUAL** (modal focus containment, target-size exceptions): automated where a scripted browser can decide them; the remainder adjudicated by a human on a **random sample of 60 generations**, blind (see below). Sampled adjudication enters the checklist secondary outcome; it does not touch the primary.
 
-- **Primary outcome:** critical+serious axe violations per generation — median per condition, per model.
-- **Secondary:** checklist pass-rate; share of generations with **zero** critical violations.
-- All raw outputs, harness, scripts and spreadsheets are published in this folder. Anyone can re-run the protocol.
+### Tokens (co-primary)
 
-## Known limitations (stated up front)
+All figures come from the API's own usage report, summed across the calls of one generation:
 
-- Automated detection covers only a fraction of real barriers — **no conformance claim** is made or implied.
-- Consumer chat interfaces drift (model updates, hidden settings); versions and dates are logged per run.
-- Author-run: the prompts and rubric are public precisely so the result can be challenged and reproduced.
+| Measure | Definition |
+|---|---|
+| Total per task | input + output + thinking tokens across the generation's calls |
+| Fixed cost | tokens of the core file (provider tokenizer count) |
+| Lazily loaded | sum of characters/tokens of the files the model requested via the tool |
+| Cached share | tokens billed at cache rates — the mechanism that makes the tool loop affordable |
+| Tokens per violation avoided | Δ tokens ÷ Δ violations, D vs each comparison condition |
+| Version delta | same tasks against a prior release of the standard (exploratory) |
+
+### Loading behaviour (secondary, pre-registered classification)
+
+The pilot showed the model loading more than the §2.1 map row: extra guides justified by rules in the core's text, plus lifecycle templates. Every file request is therefore classified, blind to outcome, as:
+
+- **map** — the guide the §2.1 row for this task names (table above);
+- **core-rule** — a file a rule in the core text instructs loading in this task's circumstances (the justifying rule is cited);
+- **template** — a `templates/` file (lifecycle context; the standard mandates loading on triggering events);
+- **unjustified** — anything else.
+
+Reported per condition: distribution of classes, and share of generations whose map guide was loaded (map hit-rate).
+
+## Blinding
+
+Before any scoring, every generated file is renamed to the SHA-256 of its content. The mapping `hash → (model, task, condition, run)` is written once, sealed (committed encrypted or held out of the analysis environment), and opened only after automated scoring and sampled adjudication are complete. Scanners are indifferent to blinding; the human adjudicator and the loading-behaviour classifier are not, which is why it exists.
+
+## Analysis plan (pre-specified)
+
+- **Primary outcome:** count of `critical`+`serious` axe violations per generation.
+- **Confirmatory contrasts:** D−B, D−C, D−A, Holm-corrected.
+- **Model:** negative-binomial mixed regression, violations ~ condition + (1 | task). Reported as incidence-rate ratios with 95% CIs.
+- **Robustness:** bootstrap difference of per-condition medians and Cliff's delta, run in parallel. Divergence between the two approaches is reported.
+- **Token primary:** total tokens per completed task, per condition — same contrasts, same correction, Gamma or log-normal mixed model as distribution dictates (choice documented before unblinding).
+- **Secondary:** share of generations with zero critical violations; checklist pass-rate; loading-behaviour distribution and map hit-rate.
+- **Exploratory, labelled as such:** everything else — engine agreement, per-category violation breakdown, tokens-per-violation-avoided, version deltas, Arm 2 descriptives.
+
+## Determinism, stated up front
+
+There is no seed parameter, and current-generation models on several providers reject sampling controls outright; where accepted, `temperature=0` has never guaranteed identical outputs. **This protocol does not promise reproducible outputs; it promises a reproducible process:** frozen prompts, logged model versions per call, all raw outputs published, and this pre-specified analysis. Anyone can re-run the protocol; anyone can re-analyse the published outputs without re-running anything.
+
+## Cost
+
+Arm 1 runs on the Gemini free tier: $0. Arm 2 runs on an existing subscription through the official client: $0 marginal. Extension arms are conditional on credits and change nothing else. The pilot measured ~90k tokens for one condition-D generation (7 API calls, cache absorbing ~43% of input), so free-tier daily caps — not money — set the collection pace.
+
+## Known limitations (stated before collection)
+
+- **Automated detection ceiling.** ~30–57% of real barriers; no conformance claim is made or implied.
+- **Fewer detectable violations ≠ better lived experience.** That bridge is Phase 2.
+- **Arm 1 simulates an agent; it is not one.** A single scoped tool reproduces the loading mechanism, not a real agent's system prompt, tool set, or history. Arm 2 exists for exactly this reason.
+- **Single model family in the primary arm.** Named in every report title; extension arms are the remedy, pre-registered here.
+- **Training contamination.** A11Y.md is public since April 2026 and may be in training data. Declared; mitigated by tasks that do not appear in the repository's examples; not eliminable. Additionally, free-tier providers state that submitted data may be used to improve models — this study feeds the standard back into that loop, which future runs must declare.
+- **Model drift under a stable name.** Free-tier models update silently; version strings and dates are logged per call, and results claim validity for the logged snapshots only.
+- **The benchmark's author is the standard's author.** Mitigated by external registration, blinding, an externally anchored checklist, a second engine, and full publication of raw outputs — not by good faith. External methodological review before collection is invited and outranks any result.
+
+## Pilot disclosure
+
+One generation (signup form, condition D) was run on 2026-08-16 under a draft harness whose grounding sentence added an instruction the standard does not contain ("load only what applies"). It was discarded and is not part of any dataset. It motivated two protocol elements: the verbatim-Quick-Start grounding rule, and the loading-behaviour classification (the model loaded six files — the map row, three core-rule-justified guides, two templates — none of it predicted by the v1 design).
+
+## Registration
+
+This protocol is registered at **OSF Registries** before the first retained generation, and the registration's identifier is added here in the same commit that starts collection. The repository tag marking the frozen protocol is signed. From that point, every departure — a model that refuses a task, a rate-limit change mid-wave, a re-collected cell — is a dated entry in `DEVIATIONS.md`.
 
 ## Phase 2 — human validation (planned, not started)
 
-Task-completion sessions over the same generated outputs with screen-reader users, recruited via community open call. Will be pre-registered in this folder before starting.
+Task-completion sessions with screen-reader users over products built with the standard **in production** — not lab prototypes. Requires an installed base first (public project registry with adoption dates, then automated field scans, then sessions). Will be pre-registered separately in this folder before starting.
 
 ## Reporting
 
-Results will be added to the repository's [Evidence & Research wiki page](https://github.com/fecarrico/A11Y.md/wiki/Evidence-and-Research) alongside the third-party benchmarks this project already tracks — measured with the same skepticism we apply to everyone else's numbers.
+Results go to the repository's [Evidence & Research wiki page](https://github.com/fecarrico/A11Y.md/wiki/Evidence-and-Research) alongside the third-party benchmarks this project already tracks — measured with the same skepticism we apply to everyone else's numbers. Raw outputs and the sealed/unsealed blinding map are published as a citable dataset (DOI) outside this repository; the repository carries the protocol, the scripts, and the aggregated results.

--- a/benchmark/PROMPTS.md
+++ b/benchmark/PROMPTS.md
@@ -1,6 +1,6 @@
 # Benchmark Prompts (fixed verbatim — pre-registered)
 
-> Used exactly as written, in every model and condition. Condition B prepends the full `docs/en/A11Y.md` followed by the line: *"Follow strictly the accessibility rules defined in the A11Y.md above."* — nothing else changes. The prompts deliberately never mention accessibility.
+> Used exactly as written, in every model and condition. What precedes each prompt is defined per condition in [`METHODOLOGY.md`](METHODOLOGY.md) §Conditions — nothing else changes between conditions. The prompts deliberately never mention accessibility — that is the point. Tasks 1–3 are unchanged from v1.0; tasks 4–10 were added in v2.0, before any data collection.
 
 ## Task 1 — Signup form
 
@@ -18,4 +18,46 @@ Create a page in plain HTML, CSS and JavaScript showing a list of 5 saved docume
 
 ```
 Create a page in plain HTML, CSS and JavaScript with a table of 10 employees (name, role, salary). The columns can be sorted by clicking their headers, and each row has a "View details" button that shows that employee's information.
+```
+
+## Task 4 — Site navigation
+
+```
+Create a page in plain HTML, CSS and JavaScript with a site header for an online bookstore. The header has a logo, a five-item navigation bar where "Categories" and "Account" open dropdown submenus on activation, and a compact menu behavior for narrow screens.
+```
+
+## Task 5 — File upload
+
+```
+Create a page in plain HTML, CSS and JavaScript where the user uploads up to 3 PDF files. Show each file in a list with its name, a progress indicator while it uploads (simulate the upload with a timer), a way to remove it, and a clear failure state when a file exceeds 5 MB.
+```
+
+## Task 6 — Image carousel
+
+```
+Create a page in plain HTML, CSS and JavaScript with a product gallery carousel of 5 images with captions. The carousel advances automatically every 4 seconds, has previous/next controls and position indicators, and clicking an indicator jumps to that image.
+```
+
+## Task 7 — Search with suggestions
+
+```
+Create a page in plain HTML, CSS and JavaScript with a search box for a city directory. As the user types, show up to 7 matching city suggestions from a hardcoded list of 50; choosing a suggestion fills the box and shows that city's detail card below.
+```
+
+## Task 8 — Product card grid
+
+```
+Create a page in plain HTML, CSS and JavaScript with a grid of 6 product cards for a coffee shop. Each card has a product photo, name, price, a short description and an "Add to cart" button; adding updates a cart counter in the page header.
+```
+
+## Task 9 — Async save with toasts
+
+```
+Create a page in plain HTML, CSS and JavaScript with a short profile form (display name, bio) and a Save button. Saving simulates a request with a timer and randomly succeeds or fails; show the outcome as a toast notification that appears in a corner and disappears after a few seconds.
+```
+
+## Task 10 — Dashboard chart
+
+```
+Create a page in plain HTML, CSS and JavaScript showing monthly revenue for one year as a bar chart drawn with SVG or canvas, plus a toggle that switches between the chart and a table of the same twelve values. Highlight the best and worst month.
 ```

--- a/benchmark/RUNBOOK.md
+++ b/benchmark/RUNBOOK.md
@@ -1,6 +1,8 @@
 # Benchmark Runbook — collecting the 54 generations
 
-> Companion to [`METHODOLOGY.md`](METHODOLOGY.md) (pre-registered, 2026-07-25). The methodology says *what* is measured and why; this file says *how to physically collect and measure*, so a run session needs no decisions — decisions made mid-collection are how bias enters a benchmark.
+> **Superseded for the primary arm.** Methodology v2.0 (2026-08-16) moved Arm 1 collection to the API, where session isolation is the default and the collector script replaces every manual step below. This file remains the reference for hand-driven collection in chat/agent interfaces — the procedure Arm 2 adapts — and will be revised alongside the collector when that arm starts.
+
+> Companion to [`METHODOLOGY.md`](METHODOLOGY.md). The methodology says *what* is measured and why; this file says *how to physically collect and measure*, so a run session needs no decisions — decisions made mid-collection are how bias enters a benchmark.
 
 ## One-time setup
 

--- a/benchmark/collect.py
+++ b/benchmark/collect.py
@@ -1,0 +1,527 @@
+#!/usr/bin/env python3
+"""
+collect.py — runs the efficacy benchmark against the Gemini API, unattended.
+
+The standard is loaded lazily: the core is read first, and a reference guide is
+consulted only when the task calls for it (A11Y.md §2.1). A plain prompt cannot
+reproduce that — paste everything and the mechanism is gone; paste the core alone
+and the model has no way to open the guide it was told to open. So this collector
+gives the model ONE tool, `read_file`, scoped to a single directory, and lets the
+mechanism run. Which files it opens is itself a measurement.
+
+Every response is written to disk verbatim before anything is parsed, so a wrong
+field name costs a re-parse, never a re-collection.
+
+    python3 collect.py --probe                 # one call, dumps the raw response
+    python3 collect.py --plan                  # what would run, without running
+    python3 collect.py --conditions A,B,D --tasks form,modal --runs 3
+    python3 collect.py --resume                # skip generations already on disk
+
+Set GEMINI_API_KEY in the environment or in benchmark/.env (git-ignored).
+Free-tier limits differ per model and change — check yours at
+https://aistudio.google.com/rate-limit and pass --rpm / --daily-cap to match.
+
+Stdlib only, no dependencies.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions"
+DEFAULT_MODEL = "gemini-3.6-flash"
+
+REPO = Path(__file__).resolve().parent.parent
+BENCH = REPO / "benchmark"
+
+# The four prompt conditions. Only D gets the real standard; C is the placebo —
+# same size, same shape, same tool, different subject. Without it, "the model did
+# better because a long organised document was in context" stays unfalsified.
+CONDITIONS = {
+    "A": {"label": "bare", "preamble": None, "docs": None},
+    "B": {"label": "generic", "preamble": "Make it accessible.", "docs": None},
+    "C": {"label": "control", "preamble": None, "docs": "control"},
+    "D": {"label": "a11ymd", "preamble": None, "docs": "standard"},
+}
+
+# Each document set carries its own entry file and its own invocation sentence.
+#
+# The standard's sentence is verbatim from its Quick Start, which is how adopters
+# are actually told to invoke it. Nothing is added: no hint that reference files
+# exist, no instruction to load selectively. Lazy loading has to emerge from
+# reading the core, or the benchmark is teaching the behaviour it claims to
+# measure. The only concession to the harness is naming the tool, since the model
+# cannot discover it otherwise.
+#
+# The control's sentence is the same sentence with the subject swapped — same
+# shape, same verb, same strictness, different domain. If it read "accessibility"
+# too, the placebo would be cueing the very thing it exists to rule out.
+DOC_SETS = {
+    "standard": {
+        "root": REPO / "docs" / "en",
+        "entry": "A11Y.md",
+        "grounding": ("When developing the frontend, follow strictly the accessibility "
+                      "rules defined in A11Y.md. Read it with the read_file tool at `{entry}`."),
+    },
+    "control": {
+        "root": BENCH / "control-standard",
+        "entry": "PERF.md",
+        "grounding": ("When developing the frontend, follow strictly the performance "
+                      "rules defined in PERF.md. Read it with the read_file tool at `{entry}`."),
+    },
+}
+
+READ_FILE_TOOL = {
+    "type": "function",
+    "name": "read_file",
+    "description": (
+        "Read a UTF-8 text file from the standard's directory. "
+        "Paths are relative to the standard's root, e.g. 'A11Y.md' or "
+        "'references/guide-forms.md'."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "path": {
+                "type": "string",
+                "description": "Path relative to the standard's root directory.",
+            }
+        },
+        "required": ["path"],
+    },
+}
+
+
+def load_dotenv(path: Path) -> None:
+    if not path.is_file():
+        return
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        os.environ.setdefault(key.strip(), value.strip().strip("'\""))
+
+
+def slugify(heading: str) -> str:
+    """Derive a short id from a task heading.
+
+    'Task 1 — Signup form' -> 'signup-form'. The pre-registered PROMPTS.md is not
+    edited to suit this script: it names tasks for humans, and the part after the
+    dash is the name worth keeping.
+    """
+    tail = re.split(r"\s+[—–-]\s+", heading.strip(), maxsplit=1)[-1]
+    slug = re.sub(r"[^a-z0-9]+", "-", tail.lower()).strip("-")
+    return slug or re.sub(r"[^a-z0-9]+", "-", heading.lower()).strip("-")
+
+
+def load_tasks(path: Path) -> dict[str, str]:
+    """Read task prompts: any '## heading' followed by a fenced block."""
+    if not path.is_file():
+        return {}
+    text = path.read_text(encoding="utf-8")
+    tasks = {}
+    for match in re.finditer(r"^##\s+(.+?)\s*$\n+```[a-z]*\n(.*?)\n```",
+                             text, re.M | re.S):
+        tasks[slugify(match.group(1))] = match.group(2).strip()
+    return tasks
+
+
+# --------------------------------------------------------------------------
+# Response shape discovery.
+#
+# The Interactions API is new and its field names are not pinned here. Rather
+# than hard-code a guess, walk the response and recognise things by shape. If
+# Google renames a wrapper, this keeps working; if it renames the leaves, --probe
+# shows you exactly what to adjust.
+# --------------------------------------------------------------------------
+
+def walk(node):
+    """Yield every dict nested anywhere in a JSON structure."""
+    if isinstance(node, dict):
+        yield node
+        for value in node.values():
+            yield from walk(value)
+    elif isinstance(node, list):
+        for item in node:
+            yield from walk(item)
+
+
+def find_function_calls(response: dict) -> list[dict]:
+    calls = []
+    for node in walk(response):
+        if node.get("type") == "function_call" and node.get("name"):
+            calls.append(node)
+        elif "functionCall" in node and isinstance(node["functionCall"], dict):
+            fc = node["functionCall"]
+            calls.append({"type": "function_call", "name": fc.get("name"),
+                          "arguments": fc.get("args") or fc.get("arguments") or {},
+                          "id": fc.get("id") or node.get("id")})
+    return calls
+
+
+def find_text(response: dict) -> str:
+    """Concatenate assistant text, ignoring text that belongs to a tool result."""
+    chunks = []
+    for node in walk(response):
+        if node.get("type") in ("function_result", "function_call"):
+            continue
+        text = node.get("text")
+        if isinstance(text, str) and text.strip():
+            chunks.append(text)
+    # De-duplicate while preserving order: nested containers can repeat a leaf.
+    seen, unique = set(), []
+    for chunk in chunks:
+        if chunk not in seen:
+            seen.add(chunk)
+            unique.append(chunk)
+    return "\n".join(unique)
+
+
+def find_usage(response: dict) -> dict:
+    for key in ("usage", "usageMetadata", "usage_metadata"):
+        value = response.get(key)
+        if isinstance(value, dict):
+            return value
+    for node in walk(response):
+        for key in ("usage", "usageMetadata", "usage_metadata"):
+            value = node.get(key)
+            if isinstance(value, dict):
+                return value
+    numeric = {}
+    for node in walk(response):
+        for key, value in node.items():
+            if isinstance(value, int) and "token" in key.lower():
+                numeric[key] = value
+    return numeric
+
+
+def sum_usage(usages: list[dict]) -> dict:
+    """Add up the per-call usage of one generation.
+
+    A generation is several API calls when the model opens a guide, so the cost of
+    a task is the sum, not the last call. Only integer fields are summed; the
+    by-modality breakdown is a list and is left to the raw responses.
+
+    Worth watching in the totals: `total_thought_tokens` (this model reasons by
+    default, and reasoning is billed) and `total_cached_tokens` (the standard's
+    core repeats across calls, so anything cached is cost that did not recur).
+    """
+    total: dict[str, int] = {}
+    for usage in usages:
+        for key, value in usage.items():
+            if isinstance(value, int) and not isinstance(value, bool):
+                total[key] = total.get(key, 0) + value
+    return total
+
+
+def find_interaction_id(response: dict) -> str | None:
+    for key in ("id", "interaction_id", "interactionId", "name"):
+        value = response.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def extract_html(text: str) -> str:
+    """Prefer a fenced html block; fall back to the raw text, unedited."""
+    fences = re.findall(r"```(?:html)?\s*\n(.*?)```", text, re.S)
+    if fences:
+        return max(fences, key=len).strip()
+    return text.strip()
+
+
+# --------------------------------------------------------------------------
+
+
+class RateLimiter:
+    def __init__(self, rpm: int):
+        self.interval = 60.0 / rpm if rpm > 0 else 0.0
+        self.last = 0.0
+
+    def wait(self) -> None:
+        if self.interval <= 0:
+            return
+        elapsed = time.monotonic() - self.last
+        if elapsed < self.interval:
+            time.sleep(self.interval - elapsed)
+        self.last = time.monotonic()
+
+
+def post(body: dict, api_key: str, timeout: int, retries: int = 4) -> dict:
+    payload = json.dumps(body).encode("utf-8")
+    delay = 5.0
+    for attempt in range(retries + 1):
+        request = urllib.request.Request(
+            API_URL, data=payload, method="POST",
+            headers={"Content-Type": "application/json", "x-goog-api-key": api_key},
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            detail = error.read().decode("utf-8", "replace")[:400]
+            if error.code in (429, 500, 502, 503, 504) and attempt < retries:
+                print(f"    HTTP {error.code}, retrying in {delay:.0f}s", flush=True)
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise RuntimeError(f"HTTP {error.code}: {detail}") from None
+        except (urllib.error.URLError, TimeoutError) as error:
+            if attempt < retries:
+                print(f"    {error}, retrying in {delay:.0f}s", flush=True)
+                time.sleep(delay)
+                delay *= 2
+                continue
+            raise RuntimeError(str(error)) from None
+    raise RuntimeError("exhausted retries")
+
+
+def read_scoped(root: Path, relative: str) -> tuple[str, bool]:
+    """Read a file, refusing anything that escapes the standard's directory."""
+    try:
+        target = (root / relative).resolve()
+        target.relative_to(root.resolve())
+    except (ValueError, OSError):
+        return f"error: path outside the standard's directory: {relative}", False
+    if not target.is_file():
+        return f"error: no such file: {relative}", False
+    return target.read_text(encoding="utf-8", errors="replace"), True
+
+
+def generate(task_prompt: str, condition: str, model: str, api_key: str,
+             limiter: RateLimiter, timeout: int, max_tool_calls: int):
+    """Run one generation to completion. Returns (record, [raw responses])."""
+    spec = CONDITIONS[condition]
+    docs = DOC_SETS[spec["docs"]] if spec["docs"] else None
+    root = docs["root"] if docs else None
+
+    parts = []
+    if spec["preamble"]:
+        parts.append(spec["preamble"])
+    if docs is not None:
+        parts.append(docs["grounding"].format(entry=docs["entry"]))
+    parts.append(task_prompt)
+
+    body = {"model": model, "input": "\n\n".join(parts)}
+    if root is not None:
+        body["tools"] = [READ_FILE_TOOL]
+
+    raws, files_read, usages = [], [], []
+    for step in range(max_tool_calls + 1):
+        limiter.wait()
+        print(f"    → call {step + 1}, waiting for the model…", end="", flush=True)
+        started = time.monotonic()
+        response = post(body, api_key, timeout)
+        elapsed = time.monotonic() - started
+        raws.append(response)
+        usage = find_usage(response)
+        usages.append(usage)
+
+        calls = find_function_calls(response)
+        summary = (f" {elapsed:.0f}s · {usage.get('total_tokens', 0):,} tokens · "
+                   f"{len(calls)} file(s) requested" if calls
+                   else f" {elapsed:.0f}s · {usage.get('total_tokens', 0):,} tokens · answered")
+        print(summary, flush=True)
+
+        if not calls or root is None:
+            break
+
+        results = []
+        for call in calls:
+            arguments = call.get("arguments") or {}
+            if isinstance(arguments, str):
+                try:
+                    arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    arguments = {}
+            requested = str(arguments.get("path", ""))
+            content, ok = read_scoped(root, requested)
+            files_read.append({"path": requested, "found": ok, "chars": len(content)})
+            print(f"      {'read ' if ok else 'MISS '} {requested} "
+                  f"({len(content):,} chars)", flush=True)
+            results.append({
+                "type": "function_result",
+                "name": call.get("name", "read_file"),
+                "call_id": call.get("id"),
+                "result": [{"type": "text", "text": content}],
+            })
+
+        interaction_id = find_interaction_id(response)
+        if not interaction_id:
+            print("    warning: no interaction id in response — stopping the tool loop",
+                  flush=True)
+            break
+        body = {"model": model, "previous_interaction_id": interaction_id,
+                "tools": [READ_FILE_TOOL], "input": results}
+    else:
+        print(f"    warning: hit --max-tool-calls ({max_tool_calls})", flush=True)
+
+    text = find_text(raws[-1])
+    record = {
+        "model": model,
+        "condition": condition,
+        "condition_label": spec["label"],
+        "collected_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "files_read": files_read,
+        "tool_calls": len(files_read),
+        "api_calls": len(raws),
+        "usage_total": sum_usage(usages),
+        "usage_per_call": usages,
+        "output_chars": len(text),
+    }
+    return record, raws, extract_html(text)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Collect benchmark generations from the Gemini API.")
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--tasks", default="", help="comma-separated task ids (default: all)")
+    parser.add_argument("--conditions", default="A,B,D",
+                        help="comma-separated: A,B,C,D (C needs benchmark/control-standard/)")
+    parser.add_argument("--runs", type=int, default=3, help="repetitions per combination")
+    parser.add_argument("--out", type=Path, default=BENCH / "runs")
+    parser.add_argument("--prompts", type=Path, default=BENCH / "PROMPTS.md")
+    parser.add_argument("--rpm", type=int, default=10, help="requests per minute ceiling")
+    parser.add_argument("--daily-cap", type=int, default=0,
+                        help="stop after N API calls (0 = no cap)")
+    parser.add_argument("--timeout", type=int, default=300,
+                        help="seconds per API call; this model reasons before "
+                             "answering, so a grounded generation is slow")
+    parser.add_argument("--max-tool-calls", type=int, default=6)
+    parser.add_argument("--resume", action="store_true", help="skip generations already on disk")
+    parser.add_argument("--plan", action="store_true", help="list what would run, then exit")
+    parser.add_argument("--probe", action="store_true",
+                        help="one minimal call; dump the raw response to calibrate parsing")
+    args = parser.parse_args()
+
+    load_dotenv(BENCH / ".env")
+    api_key = os.environ.get("GEMINI_API_KEY", "").strip()
+
+    if args.probe:
+        if not api_key:
+            print("error: GEMINI_API_KEY not set", file=sys.stderr)
+            return 2
+        body = {"model": args.model, "input": "Reply with the single word: ok.",
+                "tools": [READ_FILE_TOOL]}
+        response = post(body, api_key, args.timeout)
+        print(json.dumps(response, indent=2, ensure_ascii=False))
+        print("\n--- what this script found in it ---", file=sys.stderr)
+        print(f"interaction id : {find_interaction_id(response)}", file=sys.stderr)
+        print(f"function calls : {len(find_function_calls(response))}", file=sys.stderr)
+        print(f"usage          : {json.dumps(find_usage(response))}", file=sys.stderr)
+        print(f"text           : {find_text(response)[:120]!r}", file=sys.stderr)
+        return 0
+
+    tasks = load_tasks(args.prompts)
+    if not tasks:
+        print(f"error: no tasks found in {args.prompts} "
+              "(expected '## id' followed by a fenced block)", file=sys.stderr)
+        return 2
+
+    wanted = [t.strip() for t in args.tasks.split(",") if t.strip()] or list(tasks)
+    unknown = [t for t in wanted if t not in tasks]
+    if unknown:
+        print(f"error: unknown task(s): {', '.join(unknown)}", file=sys.stderr)
+        print(f"available: {', '.join(tasks)}", file=sys.stderr)
+        return 2
+
+    conditions = [c.strip().upper() for c in args.conditions.split(",") if c.strip()]
+    for condition in conditions:
+        if condition not in CONDITIONS:
+            print(f"error: unknown condition {condition}", file=sys.stderr)
+            return 2
+        docs = CONDITIONS[condition]["docs"]
+        if docs and not (DOC_SETS[docs]["root"] / DOC_SETS[docs]["entry"]).is_file():
+            print(f"error: condition {condition} needs "
+                  f"{DOC_SETS[docs]['root'] / DOC_SETS[docs]['entry']}, which is missing",
+                  file=sys.stderr)
+            return 2
+
+    jobs = [(task, condition, run)
+            for task in wanted for condition in conditions
+            for run in range(1, args.runs + 1)]
+
+    html_dir = args.out / "html"
+    raw_dir = args.out / "raw"
+    log_path = args.out / "log.jsonl"
+
+    def slug(task, condition, run):
+        return f"{args.model}__{task}__{condition}__run{run}"
+
+    if args.resume:
+        jobs = [j for j in jobs if not (html_dir / f"{slug(*j)}.html").is_file()]
+
+    print(f"{len(jobs)} generation(s) · model {args.model} · "
+          f"conditions {','.join(conditions)} · {args.rpm} req/min ceiling")
+    if args.plan:
+        for task, condition, run in jobs:
+            print(f"  {slug(task, condition, run)}")
+        return 0
+    if not jobs:
+        print("nothing to do — everything is already on disk")
+        return 0
+    if not api_key:
+        print("error: GEMINI_API_KEY not set (environment or benchmark/.env)", file=sys.stderr)
+        return 2
+
+    html_dir.mkdir(parents=True, exist_ok=True)
+    raw_dir.mkdir(parents=True, exist_ok=True)
+    limiter = RateLimiter(args.rpm)
+    api_calls = failures = 0
+
+    for index, (task, condition, run) in enumerate(jobs, 1):
+        name = slug(task, condition, run)
+        print(f"[{index}/{len(jobs)}] {name}", flush=True)
+        try:
+            record, raws, html = generate(
+                tasks[task], condition, args.model, api_key,
+                limiter, args.timeout, args.max_tool_calls)
+        except RuntimeError as error:
+            failures += 1
+            print(f"    FAILED: {error}", flush=True)
+            with log_path.open("a", encoding="utf-8") as log:
+                log.write(json.dumps({"id": name, "task": task, "condition": condition,
+                                      "run": run, "error": str(error)}) + "\n")
+            continue
+
+        api_calls += record["api_calls"]
+        record.update({"id": name, "task": task, "run": run})
+        (raw_dir / f"{name}.json").write_text(
+            json.dumps(raws, indent=2, ensure_ascii=False), encoding="utf-8")
+        (html_dir / f"{name}.html").write_text(html, encoding="utf-8")
+        with log_path.open("a", encoding="utf-8") as log:
+            log.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+        opened = ", ".join(f["path"] for f in record["files_read"]) or "—"
+        used = record["usage_total"]
+        print(f"    {record['api_calls']} call(s) · read: {opened}", flush=True)
+        print(f"    tokens: {used.get('total_tokens', 0):,} total · "
+              f"{used.get('total_input_tokens', 0):,} in · "
+              f"{used.get('total_output_tokens', 0):,} out · "
+              f"{used.get('total_thought_tokens', 0):,} thinking · "
+              f"{used.get('total_cached_tokens', 0):,} cached", flush=True)
+
+        if args.daily_cap and api_calls >= args.daily_cap:
+            print(f"\nreached --daily-cap ({args.daily_cap} API calls). "
+                  "Re-run with --resume to continue tomorrow.")
+            break
+
+    print(f"\ndone · {api_calls} API call(s) · {failures} failure(s)")
+    print(f"html:  {html_dir}\nraw:   {raw_dir}\nlog:   {log_path}")
+    if failures:
+        print("Failed generations are logged with their error and skipped by --resume "
+              "only once they succeed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/control-standard/PERF.md
+++ b/benchmark/control-standard/PERF.md
@@ -1,0 +1,209 @@
+# Perf Guidelines: Performance as a Baseline
+
+> **Purpose:** This document is the operational standard for AI-assisted frontend generation where runtime performance is a pre-condition of delivery, not an optimization pass scheduled for later. It defines the behavioral contract the AI operates under, the severity model it triages by, and the technical baselines every generated interface must meet before it ships.
+
+## 0. Principle Zero: Performance as Pre-condition
+
+Performance is not a feature request. It is the substrate every feature runs on. A page that renders in 800ms on the developer's machine and in 9 seconds on a mid-range phone over 4G is not "done with a caveat" — it is not done. The AI **MUST** treat the performance budget the way it treats a compile error: work that exceeds it does not ship, regardless of how complete the functionality looks.
+
+The corollary is architectural: performance cannot be bolted on. The decisions that dominate real-world speed — how much JavaScript ships, when images decode, what triggers layout, how state changes propagate to the DOM — are made at generation time, in the first draft, by whoever writes the first version of the component. When that author is an AI, the AI carries the obligation. Retrofitting speed into a slow architecture costs an order of magnitude more than generating the fast architecture first; in most teams it simply never happens.
+
+**The default rendered state MUST be the fast one.** Optimizations that depend on ideal conditions — a warm cache, a fast device, a low-latency connection — are bonuses, not baselines. The baseline is the 75th-percentile user: a mid-range Android device, throttled CPU, variable network. Every budget in this document is defined against that user, never against localhost.
+
+**Speed is compounding, in both directions.** A route that ships light keeps its next feature cheap: the reviewer sees the budget, the pattern in the codebase is the lazy one, the new dependency gets questioned. A route that shipped heavy normalizes heaviness — the next 40 KB rides in unremarked because the diff looks small next to the total. This is why the standard binds the *first* generation so tightly: the first version of a component is the template every subsequent version copies, and the cheapest moment to be fast is before anyone has learned to be slow.
+
+## 0.1. Performance Profile
+
+Before generating, the AI **MUST** know which profile governs the project. If the developer has not specified one, the AI **MUST** ask — once, at the start, never mid-task. The profile sets the budgets; the budgets decide what ships.
+
+| | 🛡️ **Strict** | ⚖️ **Standard** | 🚀 **Launchpad** |
+| :--- | :--- | :--- | :--- |
+| **For** | Commerce, news, search — traffic at scale, revenue per millisecond | Most products and internal tools | Prototypes, spikes, hackathons |
+| **LCP** (75th percentile) | ≤ 2.0 s | ≤ 2.5 s | ≤ 4.0 s |
+| **INP** (75th percentile) | ≤ 150 ms | ≤ 200 ms | ≤ 500 ms |
+| **CLS** | ≤ 0.05 | ≤ 0.1 | ≤ 0.25 |
+| **JS shipped per route** (compressed) | ≤ 100 KB | ≤ 170 KB | ≤ 300 KB |
+| **Total transfer, first view** | ≤ 500 KB | ≤ 1 MB | ≤ 2 MB |
+| **Long tasks during load** | none > 100 ms | none > 200 ms | best effort |
+| **Third-party scripts** | none synchronous | none in the critical path | declared in PERF-DECISIONS.md |
+
+Budgets are ceilings, not targets. A route that ships 90 KB of JavaScript under a 170 KB budget is not "leaving budget on the table"; it is fast. The AI **MUST NOT** treat remaining budget as an invitation.
+
+**Profile inheritance:** a component generated for a Strict project keeps its Strict discipline when copied into a Standard one. Budgets loosen at the route level by decision, never at the component level by accident.
+
+**Downgrade is a decision, not a drift.** Moving a project from Strict to Standard, or Standard to Launchpad, is recorded in `PERF-DECISIONS.md` with the reason and the owner. A budget that silently stopped being enforced is the most common way fast products become slow ones.
+
+**Budget arithmetic is per route, and the route pays for everything on it.** A 170 KB JavaScript budget is not "170 KB of our code" — it includes the framework runtime, the polyfills, the consent banner, the analytics tag and the error tracker. First-party features compete with third-party conveniences for the same bytes, and the AI **MUST** do that arithmetic explicitly when a task adds weight: state what the route currently costs, what the addition costs, and what remains. "It's only 12 KB" is only meaningful next to the number it is being added to.
+
+**Budgets are enforced where code merges, not where users complain.** A budget that lives in this document and nowhere else will be exceeded by accident and discovered by regression. Projects **SHOULD** wire the §0.1 ceilings into their build: a bundle-size check that fails the pipeline, a Lighthouse CI assertion on the preview deploy, a size-limit comment on the pull request. The AI, when asked to scaffold tooling, generates these gates from the active profile's numbers rather than inventing thresholds.
+
+## 1. Severity & Impact Model
+
+Every finding, every trade-off, and every exception in this standard is triaged by user impact, not by engineering effort:
+
+- 🔴 **CRITICAL — the user abandons.** Blocking the first paint on a script, an LCP image discovered late, an interaction that freezes the main thread past 500 ms, unbounded layout shift on load. These block delivery in every profile.
+- 🟠 **SERIOUS — the user waits.** A long task between 200–500 ms, render-blocking CSS that could be split, images decoded at 3× display size, an animation running on the main thread. Block delivery in Strict; require a `PERF-EXCEPTIONS.md` entry elsewhere.
+- 🟡 **MODERATE — the user notices.** Un-throttled scroll handlers doing cheap work, fonts swapping visibly late, a bundle with one duplicated dependency. Fix within the task when the fix is local; log otherwise.
+- 🟢 **MINOR — the profiler notices.** Micro-optimizations with no user-visible effect at current scale. **MUST NOT** be performed at the cost of readability, and **MUST NOT** be used to demonstrate diligence — a minor fix does not offset a serious finding.
+
+Severity attaches to the *user consequence*, never to the *technique*. An unthrottled resize listener is 🟢 when it toggles a class and 🔴 when it recalculates a layout tree of 4,000 nodes. The AI **MUST** state the severity it assigns and the consequence that justifies it.
+
+**Severity compounds across the load sequence.** Three 🟡 findings on the same critical path — a late-discovered font, an unsized embed, a deferred-but-heavy hydration — can add up to a user experience worse than one 🔴, because the user pays them in sequence. When triaging a page rather than a component, the AI **MUST** evaluate the load timeline as a whole: the question is not "is any single finding critical?" but "what does the 75th-percentile user actually watch happen for the first three seconds?".
+
+**Scale multiplies severity.** A finding on a component rendered once is judged at its face value; the same finding inside a list template is multiplied by the list's realistic length before triage. A 3 ms synchronous read is 🟢 in a header and 🟠 in a row template that production renders eight hundred times.
+
+## 2. AI Behavior Contract
+
+Rules the AI operates under for every generation task. Each rule is an obligation with a trigger, a mechanism, and a pointer to depth; the reference guides carry the rationale and the edge cases.
+
+- **Budget Before Beauty:** Before writing code, the AI **MUST** establish which budgets govern the task (profile, route weight, interaction deadline). Code generated without a known budget is a draft, not a deliverable. If the developer cannot supply a profile, the AI applies **Standard** and says so.
+- **Measure, Don't Guess:** A performance claim without a measurement is an opinion. The AI **MUST NOT** assert that generated code "is fast" — it states what the code does to stay within budget (bytes shipped, work deferred, layout avoided) and names the measurement that would verify it (Lighthouse run, Performance panel trace, `PerformanceObserver` in the page). *Reference: [Verification](references/guide-charts.md)*
+- **Lazy Context Loading:** Reference files (`references/`) **MUST NOT** be preloaded — they are *per-component* context, consulted only when the task involves that component type; **§2.1** states which file matches which task. `PERF.md` alone is sufficient for most generation tasks. **This does NOT apply to `templates/`:** templates are *lifecycle* context and **MUST** be loaded when their triggering event occurs (a trade-off accepted, a budget exceeded, a delivery shipped). **Template fidelity:** artifacts **MUST** be created from the files in `templates/`, never deduced from prose.
+- **Critical Path Discipline:** The AI **MUST** be able to name, for any page it generates, the exact chain of resources between navigation start and first meaningful render — and that chain **MUST** contain nothing removable. Every `<script>` without `defer`/`async` in the head, every `@import` in CSS, every synchronously-loaded font is an entry on the critical path that the AI put there and must justify. 🔴 for scripts, 🟠 for the rest.
+- **Ship What Runs:** Code generated but never executed on the route is 🟠 debt. The AI **MUST NOT** import a library for one function, include a polyfill without a target-browser reason, or generate utility modules "for later". Dead code is measured, not estimated: if the coverage panel would grey it out on first load, it does not belong in the first-load bundle.
+- **The Main Thread Is Sacred:** Between user input and visual response the main thread belongs to the user. The AI **MUST** keep any single task under the profile's long-task ceiling, chunk or defer work that exceeds it (`requestIdleCallback`, `setTimeout` slicing, a worker), and **MUST NOT** perform synchronous layout reads inside loops that also write styles. *Reference: [Charts & Heavy Rendering](references/guide-charts.md)*
+- **Layout Stability:** Every asynchronously-arriving element — image, ad, embed, font, fetched content — **MUST** have its space reserved before it arrives: explicit dimensions, `aspect-ratio`, or a sized container. Content that pushes other content after first paint is 🔴 in the viewport, 🟠 below it. *Reference: [Loading & Skeletons](references/guide-loading-skeleton.md)*
+- **Image Discipline:** Images are the largest bytes on most pages and the most common LCP element. The AI **MUST** emit modern formats with fallbacks, `srcset`/`sizes` matched to actual display sizes, explicit `width`/`height`, lazy loading below the fold — and **MUST NOT** lazy-load the LCP candidate. Fabricating a `srcset` from a single-resolution asset is a contract violation; the AI requests the missing sizes or documents the gap. *Reference: [Images & Media Bytes](references/guide-images.md)*
+- **State Changes, Not Tree Rebuilds:** Interaction handlers **MUST** touch the minimum DOM necessary. Rebuilding a list to change one row, re-rendering a table to sort an array already in memory, or serializing state into `innerHTML` on every keystroke are 🟠 by default and 🔴 past 1,000 nodes. The data operation and the DOM operation are separate steps; the AI keeps them separate.
+- **Font Loading Policy:** Text **MUST** be readable while custom fonts load: `font-display: swap` or `optional`, preloaded only for the one or two faces above the fold, subset when the character set allows it. An invisible headline waiting for a woff2 is 🔴.
+- **Third-Party Quarantine:** Every third-party script is a performance decision made by someone else. The AI **MUST** load them `async`/`defer` at most, never in the critical path, and record each one in `PERF-DECISIONS.md` with what it costs (bytes, main-thread time) and what it buys. A tag manager is not an exemption; it is a multiplier.
+- **Perceived Before Actual:** When actual latency cannot be removed (network, computation), the AI **MUST** manage perceived latency: immediate input acknowledgment, skeletons matched to final layout, optimistic UI where the operation is reversible. Perceived performance work **MUST NOT** replace budget compliance — a beautiful skeleton over a 12-second load is a 🔴 with good manners. *Reference: [Loading & Skeletons](references/guide-loading-skeleton.md)*
+- **Memory Is a Budget Too:** Long-lived pages **MUST NOT** leak: event listeners removed with their elements, observers disconnected, timers cleared, caches bounded. A dashboard that doubles its heap every hour fails this standard even if every frame is fast.
+- **Decision Memory:** When the AI chooses between viable approaches with different performance profiles (canvas vs SVG, pagination vs virtualization, eager vs lazy), it **MUST** record the choice and its trigger condition in `PERF-DECISIONS.md` — so the next generation task reuses the decision instead of re-deriving or contradicting it.
+- **Cache Policy Is Code:** Every response the page depends on has a caching decision, and the AI **MUST** make it explicitly: hashed static assets get immutable year-long caching; HTML gets revalidation; API responses get a stated freshness window or a stated reason for none. Emitting fetches and asset references without a cache strategy is generating half the code — the half the second visit was going to need. Repeat-view performance is a budget of its own: the second load **SHOULD** transfer close to zero bytes for assets that did not change.
+- **Prefetch on Intent, Not on Hope:** Navigation the user is likely to take next **MAY** be prefetched — on hover, on viewport entry of the link, on explicit idle — and prefetching **MUST** stop at likelihood. Prefetching every link on the page, or the entire next route's data "to be safe", converts one user's possible future into every user's certain cost. Intent signals first, bytes second; and never on data-saver connections, which the AI **MUST** respect via `navigator.connection` when it prefetches at all.
+- **Instrument What You Ship:** A page whose real-world performance nobody can see will regress unnoticed. When the task includes project scaffolding, the AI **MUST** include field measurement — a `PerformanceObserver` for LCP, CLS and INP reporting to whatever sink the project uses, or the project's existing RUM library wired to the new route. Lab numbers gate the release; field numbers tell you whether the gate was set at the right height. Neither replaces the other.
+- **Release Evidence:** Before any delivery to an end user — published build, deploy, shared artifact, tag — the AI **MUST** verify that a `PERF-REPORT.md` exists, was generated from `templates/PERF-REPORT.md`, and is newer than the last interface change. If it does not exist, the AI **MUST** generate it or state explicitly that the delivery carries no performance evidence. In continuous-delivery projects this rule is what triggers the report: waiting for a "final delivery" event that never happens is not compliance.
+
+## 2.1. Loading Triggers (Lazy Loading Map)
+
+*Lazy Context Loading* says **not** to preload the references. This map is the other half of the rule: it says **when** to load each one. Without it, "load it when the task involves that component" depends on the AI guessing which file matches the task — and a guide that exists but is never found is a guide that does not exist.
+
+Load **only the row that matches the task at hand**. No row applies? `PERF.md` alone is enough.
+
+| You are building or reviewing… | Load |
+| :--- | :--- |
+| button, CTA, click handler, ripple, debounced action | [`guide-buttons.md`](references/guide-buttons.md) |
+| form, field, validation, input latency, submit flow | [`guide-forms.md`](references/guide-forms.md) |
+| modal, dialog, drawer, overlay, backdrop | [`guide-modals.md`](references/guide-modals.md) |
+| navigation, menu, header, prefetching, route transitions | [`guide-navigation.md`](references/guide-navigation.md) |
+| table, data grid, large list, sorting, virtualization | [`guide-tables.md`](references/guide-tables.md) |
+| image, gallery, hero, media bytes, LCP element | [`guide-images.md`](references/guide-images.md) |
+| skeleton, spinner, loading state, progress, perceived latency | [`guide-loading-skeleton.md`](references/guide-loading-skeleton.md) |
+| carousel, slider, auto-advance, swipe, scroll-snap | [`guide-carousels-sliders.md`](references/guide-carousels-sliders.md) |
+| autocomplete, typeahead, live search, suggestions | [`guide-autocomplete.md`](references/guide-autocomplete.md) |
+| toast, notification, snackbar, async feedback | [`guide-toasts-notifications.md`](references/guide-toasts-notifications.md) |
+| chart, visualization, canvas, SVG at scale, dashboards | [`guide-charts.md`](references/guide-charts.md) |
+
+**Templates — loaded by event, not by component** *(the exception declared in Lazy Context Loading)*:
+
+| When the event happens… | Load |
+| :--- | :--- |
+| a choice between viable approaches with different performance profiles is made | [`templates/PERF-DECISIONS.md`](templates/PERF-DECISIONS.md) |
+| a budget is exceeded and the overage is accepted rather than fixed | [`templates/PERF-EXCEPTIONS.md`](templates/PERF-EXCEPTIONS.md) |
+| before any delivery to an end user (build, deploy, artifact, tag) | [`templates/PERF-REPORT.md`](templates/PERF-REPORT.md) |
+
+## 3. Technical Standards (LEAN Framework)
+
+Four dimensions every generated interface is accountable to: what it **Loads**, what it **Executes**, what it **Animates**, and what it **Negotiates** over the network. The dimensions are ordered by when their costs are paid: Load costs are paid once per visit, Execute and Animate costs on every interaction and every frame, Negotiate costs whenever data moves. A page can fail any one of them independently — a light bundle with a janky scroll fails Animate; a fast first paint that fetches in a six-deep waterfall fails Negotiate — so verification in §7 exercises all four, not the one that is easiest to measure.
+
+### Load
+
+- **Critical CSS inline, the rest deferred.** Styles needed for above-the-fold render ship in the document; everything else loads without blocking. A single monolithic stylesheet in the head is acceptable under ~30 KB compressed; past that, split.
+- **JavaScript is deferred by default.** `defer` for scripts that touch the DOM, `async` for independent beacons, modules where supported. A synchronous script in the head requires a written justification and is 🔴 without one.
+- **The LCP element is discoverable in the initial HTML.** Not constructed by script, not hidden behind a client-side router's second pass, not lazy-loaded. If the hero image is the LCP, it is an `<img>` in the markup with `fetchpriority="high"`.
+- **Preload sparingly, and only what the first view provably uses:** one or two fonts, the LCP image when it lives in CSS. Preloading is stolen bandwidth — every preloaded byte delays something the parser actually asked for.
+- **Compression and caching are assumed:** long-lived immutable caching for hashed assets, revalidation for HTML.
+- **Code splits along routes and intent, not along files.** Each route ships its own code plus a shared core that is actually shared; a component used on one admin screen does not ride in the commons chunk. Dynamic `import()` marks the seams — behind interaction (a dialog opened), behind visibility (below-the-fold widgets), behind capability (an editor only some users reach).
+- **Variable fonts over families of static weights** when more than two weights are used, and self-hosted over third-party CSS indirection: one request to a file you control beats two requests through someone else's redirect chain.
+
+### Execute
+
+- **Hydrate or attach behavior after first paint**, never before. The user sees content, then the page becomes interactive — in that order.
+- **No long tasks in the load sequence.** Work that must happen at startup is sliced under the profile ceiling or moved off-thread. Parsing a 2 MB JSON payload on the main thread during load is 🔴 regardless of where the bytes came from.
+- **Read, then write.** Within any frame, batch DOM reads before DOM writes. Interleaving them forces synchronous layout — the single most common self-inflicted performance bug in generated code.
+- **Event handlers are cheap or deferred.** Input, scroll and resize handlers do trivial work synchronously (a class toggle, a flag) and schedule the rest (`requestAnimationFrame` for visual updates, idle callbacks for bookkeeping). Scroll and touch listeners that never call `preventDefault` are registered `{ passive: true }`.
+- **Timers are owned.** Every `setInterval` has a clearing owner and a visibility guard — polling a paused tab is paying for work nobody sees.
+- **Synchronous storage stays out of hot paths.** `localStorage`, `sessionStorage` and cookie parsing block the main thread; they are read once at startup into memory, written back on idle or on `visibilitychange` — never inside input handlers, render loops, or per-row logic.
+- **Workers carry the heavy lifting.** Parsing large payloads, diffing large datasets, image manipulation, search indexing — anything CPU-bound and DOM-free belongs in a worker, with transferable objects rather than structured-clone copies when the payload is large. The main thread orchestrates; it does not compute.
+- **Debounce is a contract with the user, not a constant.** Input validation debounces around 200–300 ms so feedback follows typing pauses; search-as-you-type debounces by expected result latency; window resize handlers throttle to animation frames. A single global "debounce(300)" applied everywhere is a smell — each delay is chosen against what the user is waiting for.
+
+### Animate
+
+- **Compositor properties only:** `transform` and `opacity` animate; `top`, `left`, `width`, `height`, `margin` do not. An animation that triggers layout on every frame is 🟠, and 🔴 when it runs during load or on scroll.
+- **Sixty frames or none.** An animation that cannot hold frame rate on the baseline device is removed or simplified, not shipped juddering.
+- **Animations are interruptible and finite.** Infinite decorative animation costs battery and compositor time; it must justify itself or go.
+- **Scroll effects ride the compositor or ride nothing.** Parallax, reveal-on-scroll and sticky transitions are driven by `IntersectionObserver`, CSS scroll-driven animations, or transforms scheduled in `requestAnimationFrame` — never by reading `scrollY` and writing layout properties inside a raw scroll handler, which couples frame rate to handler cost at the exact moment the compositor is busiest.
+- **Transitions carry meaning or carry nothing.** A 150–250 ms transition that communicates a state change earns its cost; an 800 ms entrance choreography on every card of a grid delays the content it decorates. When in doubt, the content wins.
+- **`will-change` is a scalpel, not a vitamin.** Applied narrowly, just before an element animates, and removed after; sprayed across a stylesheet it promotes layers until memory pays for compositor promises nothing uses.
+
+### Negotiate
+
+- **Requests are counted and owned.** The AI can state how many requests the first view makes and what each one buys. Waterfalls are flattened: independent data fetches start in parallel, dependent ones are restructured until they are independent or acknowledged in `PERF-DECISIONS.md`.
+- **Payloads match need.** An endpoint returning 400 fields for a card that renders 6 is a negotiation failure; the AI requests narrower data or documents why it cannot.
+- **Retry with backoff, cache what repeats, dedupe in flight.** Two components fetching the same resource share one request.
+- **Offline and slow-network states are designed, not discovered.** A fetch without a timeout and a failure state is unfinished code.
+- **Pagination is negotiated at the API, not simulated in the client.** Fetching two thousand records to show twenty, then "paginating" an in-memory array, moves the cost from visible (a slow list) to hidden (a slow first byte and a heavy heap). The page size travels in the request; the server does the slicing; the client asks again when the user asks for more.
+
+## 4. Rendering Directives (Strict UI Criteria)
+
+- **Reserve space for everything asynchronous** — images, embeds, fonts, fetched lists. The page's geometry at first paint is its final geometry, modulo user action. CLS budgets are in §0.1.
+- **Content-visibility for long pages:** sections far below the fold render lazily (`content-visibility: auto` with `contain-intrinsic-size`), keeping first render proportional to the viewport, not the document.
+- **Shadows, filters and blurs are budgeted:** `backdrop-filter`, large `box-shadow` spreads and `filter` chains are compositor-expensive; they appear only where the design demands them and never animate on the main thread.
+- **The DOM is as shallow as the design allows.** Wrapper divs with no rendering purpose are removed. Past ~1,500 nodes at first render, the AI virtualizes, paginates, or defers — see [`guide-tables.md`](references/guide-tables.md).
+
+## 5. Complex Component Protocol
+
+When the task involves a component with intrinsic performance risk — a data grid past a thousand rows, a real-time chart, an infinite feed, a media-heavy carousel, an editor — the AI **MUST**:
+
+1. **Name the dominant cost** (nodes, bytes, main-thread work, or network chatter) before generating, and state the strategy that bounds it (virtualization, canvas, pagination, sampling, workers).
+2. **Load the matching reference guide** from §2.1 and follow its decision table rather than improvising.
+3. **Generate the bounded version first.** The unbounded version — render everything, fetch everything — is not a starting point to optimize later; it is the anti-pattern the guide exists to prevent.
+4. **Record the strategy** in `PERF-DECISIONS.md` with the threshold that triggered it, so the next task at the same scale inherits the decision.
+
+The protocol exists because complex components fail differently: a slow button is annoying, a slow data grid is unusable, and the difference between the two is rarely visible in a demo with toy data. Demo scale is therefore part of the protocol — when generating an example or a test page for a complex component, the AI **MUST** populate it at realistic scale (the row count, image weight and update frequency production will see), or state prominently that the demo runs below scale and what changes when it does not. A virtualized list demonstrated with twelve rows demonstrates nothing.
+
+When two strategies are viable at the task's scale — pagination or virtualization, canvas or SVG, push or poll — the AI names both, states the crossover point where the answer flips, and picks the side of the crossover the task sits on. "Both would work" is an observation; the deliverable is a decision with its trigger written down.
+
+## 6. Anti-patterns (Do NOT do this)
+
+- **The Localhost Benchmark:** Concluding the page is fast because it is fast on the development machine. Development hardware is 5–20× faster than the baseline device; the claim is unfounded by construction. Verification runs throttled or it is not verification.
+- **The Spinner Cascade:** A page-level spinner, then a section spinner, then a component spinner, each replacing the last as data arrives in stages. The user watches three loading states where one reserved layout with progressive fill was possible. *Depth: [Loading & Skeletons](references/guide-loading-skeleton.md)*
+- **Blocking the First Paint on JavaScript:** A synchronous framework bundle in the head, an empty `<div id="root">`, and nothing on screen until hydration completes. The HTML the server already had is the fastest render available; discarding it is 🔴.
+- **Layout Thrash in a Loop:** Reading `offsetHeight` and writing `style` alternately across a list of elements, forcing a full synchronous layout per iteration. Batch reads, then batch writes — or use classes and let CSS do it once.
+- **The Eager Everything:** Every image loaded at once, every route's code in one bundle, every widget initialized at startup "so it's ready". Readiness the user never asked for is cost the user always pays. Load what the viewport needs; defer the rest on demonstrated intent.
+- **Re-render as State Management:** Rebuilding the component's entire DOM on every state change because it is simpler to write. Simplicity that costs a frame per keystroke is not simple for the user typing.
+- **The Unbounded List:** Rendering an array of unknown size directly into the DOM. It works in the demo with 40 items and dies in production with 12,000. Any list without an upper bound gets virtualization, pagination, or an explicit cap — decided, not defaulted. *Depth: [Tables & Large Lists](references/guide-tables.md)*
+- **Third-Party Piggyback:** Adding an analytics tag, a chat widget and a session recorder "because marketing asked", each synchronous, none measured. Every third-party script is measured main-thread time and named in `PERF-DECISIONS.md`, or it does not ship.
+- **Polling as Architecture:** `setInterval` fetch loops where an event, a push channel, or user-triggered refresh would do. Polling that survives tab blur is paying server and battery cost for an audience of zero.
+- **The Invisible Headline:** A custom font loaded without a display strategy, leaving the page's largest text invisible for the duration of a network fetch. `font-display` is not optional; it is the difference between slow and broken.
+- **The Framework for a Form:** Reaching for a full application framework, its router and its state library to render what is, on inspection, a form and a thank-you message. The baseline cost of the stack must be justified by the complexity of the product, not by the familiarity of the author. When the AI is free to choose, it prices the stack against the §0.1 budget before writing the first import.
+- **The Barrel Import:** `import { one } from '../components'` pulling an index that re-exports sixty modules, defeating tree-shaking and shipping the catalog to use the item. Imports point at the module that defines the symbol; barrels are for authoring convenience, and build configurations that neutralize their cost must be verified, not assumed.
+- **Hidden but Rendered:** Building all five tab panels, all steps of the wizard, or the entire mega-menu into the DOM at load and hiding them with `display: none`. The browser still parses, styles and lays out what nobody asked to see. Content behind interaction is constructed behind interaction — or, where SEO requires its presence, rendered under `content-visibility` so its cost is deferred with it.
+- **Console Left Running:** `console.log` of large objects in loops and render paths surviving into production. Logging serializes; serialization costs; and a debug artifact that measurably slows the page is a defect like any other.
+- **The Metric Chase:** Optimizing the score instead of the experience — inlining everything to win a lab audit while real users on real networks pay for an uncacheable megabyte of HTML, or deferring the LCP element itself because "defer everything" scored well last sprint. The budgets in §0.1 are proxies for a user's experienced wait; when a technique improves the proxy and worsens the wait, the technique loses. Field data outranks lab data whenever the two disagree.
+
+## 7. Verification Workflow (Definition of Done)
+
+*Compliance must be verified through these steps (Refer to the [**Report Template**](templates/PERF-REPORT.md) for final QA details):*
+
+- [ ] **Artifacts Present:** `PERF-REPORT.md` exists, is filled from the template, and is newer than the last interface change. If any budget overage was accepted, `PERF-EXCEPTIONS.md` exists. All project artifacts are versioned, never gitignored.
+- [ ] **Budgets Measured:** LCP, INP and CLS measured at the profile's percentile under throttling (4× CPU, Fast 3G or the project's declared baseline), not on development hardware. Numbers recorded in the report next to their budgets.
+- [ ] **Critical Path Audited:** every resource between navigation and first meaningful render enumerated; nothing render-blocking that could be deferred; LCP element discoverable in initial HTML.
+- [ ] **Weight Within Budget:** compressed JS and total transfer per route measured against §0.1; the coverage panel shows no grey majority on first load.
+- [ ] **Main Thread Clean:** a recorded trace of load plus the three primary interactions shows no long task past the profile ceiling; input handlers respond within the INP budget.
+- [ ] **Stability Verified:** a full load and the three primary interactions produce no layout shift beyond budget; asynchronous content arrives into reserved space.
+- [ ] **Degraded Network Pass:** one full pass on the throttled profile with cache disabled; loading states appear, nothing times out silently, failure states render.
+- [ ] **Memory Steady:** for long-lived pages, heap snapshots before and after ten minutes of representative use differ by bounded, explainable amounts.
+- [ ] **Repeat View Verified:** a second load with warm cache transfers only HTML and changed data; hashed assets are served from cache; the repeat-view LCP beats the first-view LCP by a margin that shows the cache policy working.
+- [ ] **Third Parties Accounted:** every third-party script on the route appears in `PERF-DECISIONS.md` with its measured cost; removing them all in a trace shows the delta the page is paying for them, and that delta is a number someone accepted on purpose.
+
+> **Agents without a browser.** Several checkpoints above require a browser and a profiler. A headless agent **MUST** still produce the `PERF-REPORT.md`, marking those items `[ ]` with the reason and naming who must run them. A partial, honest report is evidence; a missing report is not. The AI **MUST NOT** mark as verified any measurement it cannot reproduce.
+
+---
+
+### 📚 Reference & Templates Library
+
+**Technical Guides:** [Buttons & Handlers](references/guide-buttons.md) | [Forms & Input Latency](references/guide-forms.md) | [Modals & Overlays](references/guide-modals.md) | [Navigation & Prefetching](references/guide-navigation.md) | [Tables & Large Lists](references/guide-tables.md) | [Images & Media Bytes](references/guide-images.md) | [Loading & Skeletons](references/guide-loading-skeleton.md) | [Carousels & Sliders](references/guide-carousels-sliders.md) | [Autocomplete & Live Search](references/guide-autocomplete.md) | [Toasts & Notifications](references/guide-toasts-notifications.md) | [Charts & Heavy Rendering](references/guide-charts.md)
+
+**Project Artifacts** *(versioned, not optional — see Sections 2 and 7):* [Performance Report](templates/PERF-REPORT.md) · before each delivery | [Exceptions Log](templates/PERF-EXCEPTIONS.md) · whenever an overage is accepted | [Decisions Log](templates/PERF-DECISIONS.md) · at each choice between viable strategies

--- a/benchmark/control-standard/references/guide-autocomplete.md
+++ b/benchmark/control-standard/references/guide-autocomplete.md
@@ -1,0 +1,9 @@
+# Autocomplete & Live Search Guide
+
+> **Scope:** Typeahead, suggestions, live filtering
+
+## Core Rules
+1. **Debounce to intent:** Fire the lookup 200–300 ms after the last keystroke, never per keypress.
+2. **Cancel stale requests:** Abort the in-flight fetch when a newer query supersedes it (`AbortController`); stale responses MUST NOT render.
+3. **Cache by prefix:** Results for `"par"` seed the list for `"pari"`; repeat queries within the session hit memory, not network.
+4. **Bound the list:** Render at most the visible suggestions (7–10); never the full match set.

--- a/benchmark/control-standard/references/guide-buttons.md
+++ b/benchmark/control-standard/references/guide-buttons.md
@@ -1,0 +1,20 @@
+# Buttons & Handlers Guide
+
+> **Scope:** Click handling, action latency, double-submit protection
+
+## Core Rules
+1. **Acknowledge within one frame:** the pressed state (class toggle, style change) applies synchronously; the work the click triggers is scheduled after paint.
+2. **Heavy work leaves the handler:** anything past a few milliseconds moves to `requestAnimationFrame` (visual), a microtask (state), or a worker (compute) — the handler itself stays under the INP budget.
+3. **Disable on dispatch:** an async action disables its trigger (or dedupes in flight) so double-clicks cannot double-submit; re-enable on settle, success or failure alike.
+4. **Delegate repeated handlers:** one listener on the list container beats one per row; per-item closures at scale are heap and setup cost.
+5. **No layout in the click path:** reading `offsetWidth` or forcing style recalculation inside a click handler stalls the very interaction being measured.
+
+## Bad Example
+```js
+button.addEventListener('click', () => {
+  const rows = buildAllRows(data);         // heavy, synchronous
+  table.innerHTML = rows;                  // full rebuild
+  button.style.width = button.offsetWidth; // forced layout
+});
+```
+- **Why it fails:** the user's click pays for computation, a tree rebuild and a forced layout before any visual response — the three costs this guide exists to keep out of the handler.

--- a/benchmark/control-standard/references/guide-carousels-sliders.md
+++ b/benchmark/control-standard/references/guide-carousels-sliders.md
@@ -1,0 +1,31 @@
+# Carousels & Sliders Guide
+
+> **Scope:** Galleries, auto-advance, swipe — media weight and timers
+
+## Core Rules
+
+1. **Load the visible slide plus one neighbor.** A five-slide gallery at load costs one image, not five; neighbors load on approach (`IntersectionObserver` or index math on navigation). The first slide is an LCP candidate — it gets `fetchpriority="high"` and is never lazy.
+2. **Scroll-snap over script.** `scroll-snap-type` with native scrolling gives compositor-driven swiping for free; JavaScript position math runs only for what CSS cannot express (auto-advance, indicators).
+3. **Auto-advance is owned by the page's visibility.** The interval pauses on `visibilitychange`, on hover, and on user interaction with the carousel; a timer sliding images in a background tab is pure waste. One timer per carousel, cleared on teardown.
+4. **Transforms move slides.** The track animates with `transform: translateX()`; animating `left`/`margin` lays out every slide per frame.
+5. **Indicators are cheap nodes,** not re-rendered lists — toggle a class on the active dot.
+
+## Bad Example
+
+```js
+setInterval(() => {
+  track.innerHTML = slides.map(render).join('');  // rebuild all slides
+  track.style.marginLeft = `-${i * 100}%`;        // layout property
+  i = (i + 1) % slides.length;
+}, 3000);
+```
+
+- **Why it fails:** every three seconds, every slide re-renders (image decode included), the track forces layout, and the timer runs whether or not anyone can see the page. This is the eager-everything and polling-as-architecture anti-patterns wearing a UI.
+
+## Checklist
+- [ ] First slide in initial HTML, priority-hinted; others deferred.
+- [ ] Swipe rides native scroll with snap points.
+- [ ] Auto-advance pauses on hidden tab, hover and interaction.
+- [ ] Navigation patches classes/transforms; zero rebuilds.
+- [ ] Slide images carry explicit dimensions; the track never resizes on advance.
+- [ ] Teardown (SPA navigation) clears the interval and observers.

--- a/benchmark/control-standard/references/guide-charts.md
+++ b/benchmark/control-standard/references/guide-charts.md
@@ -1,0 +1,122 @@
+# Charts & Heavy Rendering Guide
+
+> **Scope:** Data visualization, canvas vs SVG, dashboards, real-time series
+
+## The rule behind every rule
+
+A chart is a rendering budget with axes. Its cost has three independent components — **data preparation** (parse, aggregate, decimate), **scene construction** (nodes or draw calls), and **update frequency** (how often the first two repeat) — and the guide's whole job is keeping each one proportional to what the user can actually perceive. A screen is ~2,000 pixels wide; a series of 200,000 points offers the user at most 2,000 distinguishable positions. Rendering the other 198,000 is cost without information.
+
+## Choosing the substrate
+
+| Situation | Substrate | Why |
+| :--- | :--- | :--- |
+| ≤ ~1,000 elements, interactivity per element (hover, click, tooltips) | **SVG** | DOM events, CSS styling and inspectability for free; node count is the limit |
+| 1,000–100,000 points, redraw-heavy, pan/zoom | **Canvas 2D** | one node, draw-call cost instead of tree cost; you own hit-testing |
+| > 100k points, continuous streaming, multiple linked charts | **WebGL / offscreen** | GPU-side geometry; the only substrate where "all the data" is even discussable |
+| Sparklines, static thumbnails | **Inline SVG or pre-rendered image** | no runtime at all beats every runtime |
+
+The decision is recorded in `PERF-DECISIONS.md` with the scale that drove it (§5 of the core). A dashboard that picked SVG at 300 points and now renders 30,000 does not "optimize the SVG" — it crosses the substrate boundary the original decision named.
+
+## Good Examples
+
+### 1. Decimate to the pixel grid
+```js
+// LTTB (largest-triangle-three-buckets) down to ~2 points per pixel
+const width = canvas.clientWidth;
+const drawable = lttb(series, width * 2);
+draw(ctx, drawable);
+```
+- **Why:** the eye cannot resolve more than the pixel grid; LTTB keeps the visual shape (peaks, outliers) while cutting draw cost by orders of magnitude. Decimation happens on data change, not on every frame.
+
+### 2. Prepare off-thread, draw on-thread
+```js
+worker.postMessage({ raw, width }, [raw.buffer]);   // transfer, don't copy
+worker.onmessage = ({ data }) => {
+  prepared = data;                                   // typed array back
+  scheduleDraw();
+};
+```
+- **Why:** parsing and aggregating a large payload is CPU work with no DOM dependency — exactly what workers are for. The main thread receives draw-ready typed arrays; transferables make the handoff free.
+
+### 3. One frame, one draw
+```js
+let pending = false;
+function scheduleDraw() {
+  if (pending) return;
+  pending = true;
+  requestAnimationFrame(() => { pending = false; render(prepared); });
+}
+```
+- **Why:** twelve state changes between frames produce one render, not twelve. Every data source, resize and interaction funnels through the same scheduler; the frame budget is spent once.
+
+### 4. Resize without thrash
+```js
+const ro = new ResizeObserver(entries => {
+  const { inlineSize, blockSize } = entries[0].contentBoxSize[0];
+  canvas.width = inlineSize * devicePixelRatio;
+  canvas.height = blockSize * devicePixelRatio;
+  scheduleDraw();
+});
+ro.observe(container);
+```
+- **Why:** `ResizeObserver` delivers geometry without polling or layout reads in a resize handler; scaling by `devicePixelRatio` keeps the chart sharp without CSS-pixel overdraw on high-density screens.
+
+### 5. Streaming with a ring buffer
+```js
+const buf = new Float32Array(WINDOW);   // fixed memory
+function push(v) { buf[i++ % WINDOW] = v; dirty = true; }
+setInterval(() => { if (dirty && !document.hidden) { dirty = false; scheduleDraw(); } }, 100);
+```
+- **Why:** a live chart's memory does not grow with uptime, redraws are capped at 10 fps (plenty for telemetry) and stop entirely in hidden tabs. The alternative — `data.push()` forever plus draw-per-message — is a leak with a frame cost attached.
+
+## Bad Examples
+
+### 1. The DOM as plotter
+```js
+points.forEach(p => {
+  const dot = document.createElement('div');
+  dot.style.cssText = `left:${x(p)}px; top:${y(p)}px`;
+  chart.append(dot);   // 40,000 absolutely-positioned divs
+});
+```
+- **Why it fails:** forty thousand nodes cost style, layout and memory before the first pixel paints, and every hover recalculates against all of them. This is the unbounded-list anti-pattern drawn as a picture.
+
+### 2. Redraw per datum
+```js
+socket.on('tick', (point) => {
+  data.push(point);
+  chart.destroy();
+  chart = new Chart(ctx, { data });   // full reconstruction, 60×/s
+});
+```
+- **Why it fails:** construction cost (scales, layout, legend) is paid per message instead of per visible change. Streams mutate buffers and schedule frames; they never reconstruct.
+
+### 3. Animated everything
+```js
+options.animation = { duration: 800 };  // on a dashboard of 12 charts
+```
+- **Why it fails:** twelve charts × 800 ms of entrance tweening is ten seconds of aggregate main-thread animation for information the user came to *read*. Dashboards render settled; animation is reserved for state *changes* the user triggered, and stays under 250 ms.
+
+### 4. The hidden dashboard that keeps drawing
+```js
+setInterval(fetchAndRedrawAll, 5000);   // runs in background tabs
+```
+- **Why it fails:** a wall of charts redrawing in a tab nobody is looking at is the polling anti-pattern at its most expensive. Gate on `document.hidden`, and on re-show, fetch once and settle.
+
+## Dashboards specifically
+
+- **Charts share one scheduler.** N charts each with their own `requestAnimationFrame` loop contend; one coordinator draws the dirty subset per frame, in priority order (viewport first).
+- **Below-the-fold charts don't exist yet.** Construct on approach (`IntersectionObserver`), render a static placeholder image or empty reserved box until then.
+- **Linked interactions batch.** A crosshair moving across six linked charts updates six overlays in one frame — overlays being cheap layers (a line, a label), never full redraws of the six scenes.
+- **The data layer dedupes.** Six charts over the same series hold one copy of the prepared arrays, not six transformations of the same fetch.
+
+## Checklist
+- [ ] Substrate chosen from the table and recorded with its scale threshold.
+- [ ] Points drawn ≤ ~2× horizontal pixels; decimation on data change.
+- [ ] Heavy preparation in a worker with transferables past ~1 MB of data.
+- [ ] All redraws funnel through one rAF scheduler; no draw outside it.
+- [ ] Streaming charts: fixed-size buffers, visibility-gated, capped fps.
+- [ ] Resize via `ResizeObserver`, scaled by `devicePixelRatio`.
+- [ ] Dashboard: lazy construction below fold, shared scheduler, deduped data.
+- [ ] Entrance animation absent or ≤ 250 ms; hidden tabs draw nothing.
+- [ ] Tooltip and crosshair layers are overlays; base scenes redraw only on data or geometry change.

--- a/benchmark/control-standard/references/guide-forms.md
+++ b/benchmark/control-standard/references/guide-forms.md
@@ -1,0 +1,44 @@
+# Forms & Input Latency Guide
+
+> **Scope:** Validation timing, input responsiveness, submit flow
+
+## Good Examples
+
+### 1. Validation off the keystroke path
+```js
+input.addEventListener('input', () => {
+  clearTimeout(pending);
+  pending = setTimeout(() => validate(input.value), 250);
+});
+```
+- **Why:** the keystroke handler does nothing but reschedule; validation runs when typing pauses. Typing latency stays at zero cost regardless of how expensive the validation is.
+
+### 2. Submit with immediate acknowledgment
+```js
+form.addEventListener('submit', (e) => {
+  e.preventDefault();
+  submitBtn.disabled = true;            // same frame
+  status.textContent = 'Saving…';       // same frame
+  api.save(data).finally(() => { submitBtn.disabled = false; });
+});
+```
+- **Why:** the user sees a response in the same frame as the click; the network cost is real but no longer *felt* as unresponsiveness, and the disabled trigger prevents a double submit.
+
+## Bad Examples
+
+### 1. Synchronous validation per keystroke
+```js
+input.addEventListener('input', () => {
+  const result = validateAgainstRules(input.value, allRules); // 12ms
+  rerenderErrorPanel(result);                                  // rebuilds DOM
+});
+```
+- **Why it fails:** 12 ms of work plus a DOM rebuild on every keystroke turns a 60-word field into a slideshow. Validation cost scales with rules; typing cost must not.
+
+### 2. Storage on the hot path
+```js
+input.addEventListener('input', () => {
+  localStorage.setItem('draft', JSON.stringify(formState));
+});
+```
+- **Why it fails:** synchronous storage serializes and blocks per keystroke. Drafts persist on `visibilitychange` or a long idle debounce, not per character.

--- a/benchmark/control-standard/references/guide-images.md
+++ b/benchmark/control-standard/references/guide-images.md
@@ -1,0 +1,72 @@
+# Images & Media Bytes Guide
+
+> **Scope:** Formats, responsive sizing, decode cost, LCP images
+
+## The rule behind every rule
+
+Images are the heaviest bytes on most pages and the most common LCP element. Every image on a route answers four questions: is it the right **format**, at the right **size**, arriving at the right **time**, into **reserved space**? A yes to all four is the whole guide; everything below is the mechanics.
+
+## Good Examples
+
+### 1. The LCP hero
+```html
+<img src="hero-1280.avif"
+     srcset="hero-640.avif 640w, hero-1280.avif 1280w, hero-1920.avif 1920w"
+     sizes="100vw"
+     width="1280" height="720"
+     fetchpriority="high" decoding="async">
+```
+- **Why:** discoverable in the initial HTML (no CSS background, no JS insertion), priority-hinted so the preload scanner fetches it first, sized so layout is stable, and served in a modern format at the display resolution — not the original upload.
+
+### 2. Below-the-fold discipline
+```html
+<img src="product-400.webp" srcset="product-400.webp 400w, product-800.webp 800w"
+     sizes="(min-width: 900px) 33vw, 50vw"
+     width="400" height="300" loading="lazy" decoding="async">
+```
+- **Why:** `loading="lazy"` defers bytes until approach; `sizes` matches the grid so a 400-pixel card never downloads 1600 pixels; explicit dimensions reserve the box.
+
+### 3. Art direction without double downloads
+```html
+<picture>
+  <source media="(max-width: 600px)" srcset="crop-square-600.avif">
+  <img src="wide-1200.avif" width="1200" height="500">
+</picture>
+```
+- **Why:** each viewport downloads its one appropriate crop. Hiding the unused variant with CSS downloads both.
+
+## Bad Examples
+
+### 1. The 4K thumbnail
+```html
+<img src="IMG_8842-original.jpg" style="width: 120px">
+```
+- **Why it fails:** four megabytes decoded to paint 120 pixels. The browser pays network, decode *and* memory for resolution nobody sees. Resize at build or CDN; the DOM is not an image editor.
+
+### 2. Lazy-loading the LCP
+```html
+<img src="hero.avif" loading="lazy">  <!-- first thing the user sees -->
+```
+- **Why it fails:** the lazy observer waits for layout to know the image is in-viewport — adding a round trip of delay to the one image the LCP clock is measuring. Above-the-fold images load eagerly, with priority.
+
+### 3. Background-image heroes
+```css
+.hero { background-image: url(hero.jpg); }
+```
+- **Why it fails:** invisible to the preload scanner until CSS is parsed and the element styled — routinely the difference between a 1.8 s and a 3.5 s LCP. Content images are `<img>`; CSS backgrounds are for texture.
+
+### 4. Unsized embeds
+```html
+<img src="banner.png">
+```
+- **Why it fails:** no dimensions means zero reserved height; the page assembles, then jumps when bytes arrive. `width`/`height` (or `aspect-ratio`) cost nothing and eliminate the shift.
+
+## Checklist
+- [ ] AVIF/WebP with sensible fallback; SVG for line art and icons.
+- [ ] `srcset`/`sizes` present and matched to rendered sizes — audit with DevTools' "actual vs intrinsic".
+- [ ] Every image carries `width`/`height` or `aspect-ratio`.
+- [ ] Above the fold: eager + `fetchpriority="high"` on the LCP candidate. Below: `loading="lazy" decoding="async"`.
+- [ ] No image serves more than ~2× its largest rendered resolution.
+- [ ] Icon systems ship as SVG sprite or inline — not as a font, not as PNGs.
+- [ ] Hero variants exist at the breakpoints the design actually uses — a `srcset` of one file is a caption, not a strategy.
+- [ ] Decode is `async` everywhere; nothing above the fold waits on a below-fold decode.

--- a/benchmark/control-standard/references/guide-loading-skeleton.md
+++ b/benchmark/control-standard/references/guide-loading-skeleton.md
@@ -1,0 +1,60 @@
+# Loading & Skeletons Guide
+
+> **Scope:** Perceived latency, reserved layout, progressive rendering
+
+## The rule behind every rule
+
+Loading states manage the gap between request and content. They have two jobs: keep the page's geometry stable (the skeleton reserves exactly the space the content will take) and keep the user informed that progress is real. A loading state that shifts layout when it resolves has failed the first job; one that spins forever without a failure path has failed the second.
+
+## Good Examples
+
+### 1. Skeleton that matches final geometry
+```html
+<div class="card" style="aspect-ratio: 3 / 4">
+  <div class="skeleton img" style="aspect-ratio: 16 / 10"></div>
+  <div class="skeleton line" style="width: 70%"></div>
+  <div class="skeleton line" style="width: 40%"></div>
+</div>
+```
+- **Why:** the card owns its final size before any data arrives; the swap from skeleton to content changes pixels, not positions. CLS from this component is zero by construction.
+
+### 2. Staged reveal, single layout
+```js
+const data = await fetchList();
+list.replaceChildren(...data.map(render));  // one DOM operation
+```
+- **Why:** content enters in one batch into reserved space — not row by row as items parse, each pushing the footer down another notch.
+
+### 3. Failure is a state, not an absence
+```js
+const t = setTimeout(() => showRetry(section), 8000);
+fetchSection().then(renderInto(section)).catch(() => showRetry(section)).finally(() => clearTimeout(t));
+```
+- **Why:** the skeleton has three exits — content, error, timeout — all designed. A skeleton with one exit is a spinner with better styling.
+
+## Bad Examples
+
+### 1. The spinner cascade
+```
+page spinner → header renders → section spinner → list renders → row spinners…
+```
+- **Why it fails:** the user watches three sequential loading states where one reserved layout with progressive fill was possible. Perceived time stacks; each new spinner resets the user's clock.
+
+### 2. Skeleton without dimensions
+```html
+<div class="skeleton"></div>  <!-- height: whatever the shimmer is -->
+```
+- **Why it fails:** a skeleton that does not reserve the content's real height converts into a layout shift at the worst moment — exactly when the user starts reading. It made the metric worse than no skeleton.
+
+### 3. Shimmer on the main thread
+```js
+setInterval(() => el.style.backgroundPosition = `${x++}px 0`, 16);
+```
+- **Why it fails:** animating the placeholder with script steals frames from the work that would end the loading state. Shimmer is a CSS animation on a compositor property, or nothing.
+
+## Checklist
+- [ ] Every async region reserves final geometry (dimensions, `aspect-ratio`, or min-height from real content sizes).
+- [ ] One loading state per user intention, not per component.
+- [ ] Timeout and failure paths render something actionable.
+- [ ] Shimmer/pulse is CSS-only; removing it changes no timing.
+- [ ] The fast path skips the skeleton: cached data renders directly — no flash of placeholder for content that took 40 ms.

--- a/benchmark/control-standard/references/guide-modals.md
+++ b/benchmark/control-standard/references/guide-modals.md
@@ -1,0 +1,49 @@
+# Modals & Overlays Guide
+
+> **Scope:** Dialogs, drawers, backdrops — mount cost and animation
+
+## Good Examples
+
+### 1. Construct on first open
+```js
+let dialog = null;
+openBtn.addEventListener('click', () => {
+  if (!dialog) dialog = buildDialog();   // built once, on demand
+  document.body.append(dialog);
+  requestAnimationFrame(() => dialog.classList.add('open'));
+});
+```
+- **Why:** the dialog costs nothing at page load — no nodes, no images, no listeners. The build happens on the click that proves it is needed, and the `requestAnimationFrame` lets the entrance transition run from a painted initial state.
+
+### 2. Compositor-only entrance
+```css
+.dialog { transform: translateY(8px); opacity: 0; transition: transform .2s, opacity .2s; }
+.dialog.open { transform: none; opacity: 1; }
+.backdrop { opacity: 0; transition: opacity .2s; background: rgb(0 0 0 / .5); }
+```
+- **Why:** `transform` and `opacity` animate on the compositor; the page behind does not re-layout. A `backdrop-filter: blur()` here is the expensive alternative — budget it consciously or use a plain translucent backdrop.
+
+## Bad Examples
+
+### 1. All dialogs in the DOM at load
+```html
+<div class="modal" id="confirm-delete" style="display:none">…</div>
+<div class="modal" id="edit-profile" style="display:none">…</div>
+<div class="modal" id="share-sheet" style="display:none">…</div>
+```
+- **Why it fails:** every hidden dialog is parsed, styled and kept in memory for a page where the user may open none of them. Hidden-but-rendered is load cost without load value.
+
+### 2. Animating layout properties
+```css
+.drawer { left: -320px; transition: left .3s; }
+.drawer.open { left: 0; }
+```
+- **Why it fails:** animating `left` triggers layout every frame for the drawer *and* anything whose geometry depends on it. `transform: translateX()` produces the same motion on the compositor.
+
+## Checklist
+- [ ] Zero dialog nodes in the DOM before first open (unless SSR requires them — then `content-visibility` defers their cost).
+- [ ] Entrance/exit animate `transform`/`opacity` only.
+- [ ] Media inside the dialog loads when the dialog opens, not with the page.
+- [ ] Closing removes or hides without leaking listeners or timers.
+- [ ] Backdrop uses translucency, not `backdrop-filter`, unless the profile's frame budget was checked with it on.
+- [ ] Reopening reuses the built dialog; teardown clears its timers.

--- a/benchmark/control-standard/references/guide-navigation.md
+++ b/benchmark/control-standard/references/guide-navigation.md
@@ -1,0 +1,11 @@
+# Navigation & Prefetching Guide
+
+> **Scope:** Headers, menus, route transitions, prefetch policy
+
+## Core Rules
+1. **The header is critical path:** it renders in the initial HTML, styled by critical CSS, with no script required for its first paint.
+2. **Dropdowns construct on first open,** not at load — a mega-menu nobody opens is cost nobody sees. Cache the built panel for reopens.
+3. **Prefetch on intent:** hover or `IntersectionObserver` on the link arms a prefetch of the next route's code and data; never prefetch the whole nav graph.
+4. **Respect the connection:** skip prefetching under `saveData` or `2g`/`slow-2g` effective types.
+5. **Transitions stay compositor-side:** the menu slide is a `transform`, the backdrop a `opacity` fade; layout-shifting menus are a defect.
+6. **Sticky headers use `position: sticky`,** not scroll listeners repositioning with JavaScript.

--- a/benchmark/control-standard/references/guide-tables.md
+++ b/benchmark/control-standard/references/guide-tables.md
@@ -1,0 +1,10 @@
+# Tables & Large Lists Guide
+
+> **Scope:** Data grids, sorting, virtualization thresholds
+
+## Core Rules
+1. **Sort the data, not the DOM:** Sorting reorders the in-memory array and patches rows; it MUST NOT rebuild the table.
+2. **Virtualize past ~500 rows:** Render only the viewport plus overscan; recycle row nodes. Below that, plain rendering is simpler and fast enough.
+3. **Fixed row geometry:** Uniform row heights make virtualization O(1); measure-on-render schemes are a last resort.
+4. **Paginate at the API** when the set is unbounded — the client never holds what the user cannot reach.
+5. **Defer cell extras:** Sparklines, avatars and badges inside rows lazy-load on visibility, not with the table shell.

--- a/benchmark/control-standard/references/guide-toasts-notifications.md
+++ b/benchmark/control-standard/references/guide-toasts-notifications.md
@@ -1,0 +1,50 @@
+# Toasts & Notifications Guide
+
+> **Scope:** Async feedback, snackbars, notification queues
+
+## Good Examples
+
+### 1. One container, recycled
+```js
+const stack = document.getElementById('toast-stack'); // exists in initial HTML, empty
+function toast(msg) {
+  const el = pool.pop() ?? document.createElement('div');
+  el.className = 'toast'; el.textContent = msg;
+  stack.append(el);
+  requestAnimationFrame(() => el.classList.add('show'));
+  setTimeout(() => dismiss(el), 4000);
+}
+function dismiss(el) {
+  el.classList.remove('show');
+  el.addEventListener('transitionend', () => { el.remove(); pool.push(el); }, { once: true });
+}
+```
+- **Why:** the stack container is reserved space — toasts entering and leaving shift nothing else on the page. Nodes are pooled instead of churned, and every timer has an owner and an end.
+
+### 2. Entrance on the compositor
+```css
+.toast { transform: translateY(12px); opacity: 0; transition: transform .18s, opacity .18s; }
+.toast.show { transform: none; opacity: 1; }
+```
+- **Why:** corner toasts animate over the page, not within its layout; `transform`/`opacity` keep the page's frame budget untouched even when several stack.
+
+## Bad Examples
+
+### 1. Toast as layout event
+```js
+banner.style.height = 'auto';       // inserted above content
+content.style.marginTop = '56px';   // pushes the page down
+```
+- **Why it fails:** feedback that reflows the page charges every element below it and shifts what the user was reading. Notifications overlay; they do not displace.
+
+### 2. Unbounded queue
+```js
+socket.on('event', (e) => toast(e.message));
+```
+- **Why it fails:** a chatty socket turns the corner of the screen into an unbounded render loop. Queue with a cap, coalesce repeats ("3 new messages"), and drop what the user can no longer act on.
+
+## Checklist
+- [ ] Toast container present and sized from the initial HTML; no CLS on show/hide.
+- [ ] Timers cleared on dismiss and on page hide.
+- [ ] Bursts coalesce; the queue has a maximum.
+- [ ] Toast text renders without loading anything: no icon fetch, no font face unique to notifications.

--- a/benchmark/control-standard/templates/PERF-DECISIONS.md
+++ b/benchmark/control-standard/templates/PERF-DECISIONS.md
@@ -1,0 +1,27 @@
+# Performance Decisions Log (Template)
+
+> One entry per choice between viable strategies with different performance profiles (Decision Memory, `PERF.md` §2). The log exists so the next task at the same scale **reuses** the decision instead of re-deriving or contradicting it. Newest first.
+
+---
+
+## [YYYY-MM-DD] — [Component or route]
+
+- **Decision:** [e.g., Virtualized rows over pagination for the audit table]
+- **Trigger / scale:** [what made this a decision — e.g., dataset crosses 500 rows in production]
+- **Alternatives priced:** [what else was viable and what it would have cost — bytes, frames, requests]
+- **Crossover:** [the condition under which this decision flips — e.g., "if rows become variable-height, revisit: measurement cost changes the math"]
+- **Cost accepted:** [what this choice pays — e.g., +6 KB virtualization helper on the route]
+- **Owner:** [who confirms this stays right as the product grows]
+
+---
+
+## Example
+
+## 2026-08-10 — /reports data grid
+
+- **Decision:** Canvas rendering for the 40k-point scatter; SVG kept for the ≤ 200-element summary charts.
+- **Trigger / scale:** Production series grew past 10k points; SVG hover latency crossed 200 ms.
+- **Alternatives priced:** SVG with decimation (still 4k nodes, 90 ms style cost); WebGL (overkill below 100k, +38 KB runtime).
+- **Crossover:** Revisit at sustained >100k points or if per-point interaction is required (canvas hit-testing budget: 2 ms).
+- **Cost accepted:** Own hit-testing code (+1.2 KB); tooltips reimplemented over canvas.
+- **Owner:** frontend platform.

--- a/benchmark/control-standard/templates/PERF-EXCEPTIONS.md
+++ b/benchmark/control-standard/templates/PERF-EXCEPTIONS.md
@@ -1,0 +1,40 @@
+# Perf Exceptions Log (Template)
+
+This document logs known budget overages against the performance standard (`PERF.md` §0.1) that have been temporarily accepted.
+
+> **Objective:** Provide technical transparency by documenting *where*, *why*, and *by how much* the budgets are exceeded, and who accepted that cost on the user's behalf.
+
+> **Rules:**
+> 1. An exception is **temporary** and does not change the budget.
+> 2. Every exception MUST have a **risk owner**, an **approver**, a **tracking issue**, and an **expiry date** — "waiting on the vendor" still gets a review date.
+> 3. Scope is the **narrowest practical**: one route, one asset, one third-party — never "the app is heavy".
+> 4. At expiry, the exception is reviewed: fixed and removed, or consciously renewed with a new date. **Never silently suppressed.**
+> 5. **AI duty:** in review mode, the AI MUST flag any exception past its expiry date as 🟠 SERIOUS technical debt.
+> 6. This log is a **versioned project record** — never add it to `.gitignore`. Accepted overages must be visible in pull requests and auditable later.
+
+---
+
+## 🛑 Exception Log
+
+### 1. Basic Details
+- **Exception ID:** [e.g., PEX-2026-001]
+- **Route / Component:** [e.g., /checkout payment step]
+- **Budget Affected:** [e.g., JS per route — 214 KB against a 170 KB Standard budget]
+- **Severity (User Impact):** [🔴 Critical | 🟠 Serious | 🟡 Moderate | 🟢 Minor]
+- **Risk Owner:** [Who is accountable — a person, not a team]
+- **Approved by:** [Who signed off on the overage — lead/PO]
+- **Tracking Issue:** [Link to the backlog item where this debt is chased]
+
+### 2. Overage Description
+- **What exceeds, and by how much?** [The measured number next to the budget, and the conditions of measurement].
+- **Why did it happen?** [The payment SDK ships 90 KB and offers no slim build; the legacy grid cannot be virtualized this cycle; etc.].
+
+### 3. Mitigation While Open
+- **What keeps the experience acceptable meanwhile?** [The SDK loads on interaction with the payment step, not at route load; the grid caps at 200 rows with server paging; etc.]
+
+### 4. Resolution Plan and Expiry
+- **Expiry (review-by date):** [YYYY-MM-DD — mandatory]
+- **Resolution Criterion:** [What measured number, under what conditions, closes this entry?]
+
+---
+*Blank copy (paste below as you create new exceptions).*

--- a/benchmark/control-standard/templates/PERF-REPORT.md
+++ b/benchmark/control-standard/templates/PERF-REPORT.md
@@ -1,0 +1,62 @@
+# Performance Verification Report (Template)
+
+> Generated from `templates/PERF-REPORT.md` before any delivery to an end user (`PERF.md` §2, Release Evidence). One report per delivery; the report is **versioned with the code it describes** and must be newer than the last interface change. Status may be ✅ PASS, ⚠️ CONDITIONAL (open exceptions referenced), or ❌ FAIL — a report claiming PASS while carrying unchecked items is invalid.
+
+## 📌 Measurement Context
+
+- **Date / build:** [YYYY-MM-DD · commit or tag]
+- **Profile in force:** [🛡️ Strict | ⚖️ Standard | 🚀 Launchpad] — budgets from `PERF.md` §0.1
+- **Baseline device/network:** [e.g., 4× CPU throttle, Fast 3G, cold cache — state exactly what "throttled" meant]
+- **Tooling and versions:** [Lighthouse X.Y, browser build, RUM source if field data is cited]
+- **Who measured:** [person/agent — and which items below they could not reproduce]
+
+## 1. Core Web Vitals (lab, at the profile percentile)
+
+| Metric | Budget | Measured | Verdict |
+| :--- | ---: | ---: | :--- |
+| LCP | [from profile] | [ ] | [ ] |
+| INP (worst primary interaction) | [from profile] | [ ] | [ ] |
+| CLS (load + primary interactions) | [from profile] | [ ] | [ ] |
+
+- [ ] Measured under the declared throttle, not on development hardware.
+- [ ] LCP element named: [which element] — discoverable in initial HTML: [yes/no]
+
+## 2. Weight
+
+| Measure | Budget | Measured |
+| :--- | ---: | ---: |
+| JS per route (compressed) | [ ] | [ ] |
+| Total transfer, first view | [ ] | [ ] |
+| Coverage: unused JS/CSS on first load | — | [ %] |
+
+- [ ] No route exceeds its budget, or the overage is logged in `PERF-EXCEPTIONS.md`: [IDs]
+
+## 3. Critical Path
+
+- [ ] Every render-blocking resource enumerated; each one justified or deferred.
+- [ ] No synchronous third-party script; third parties listed in `PERF-DECISIONS.md`.
+- [ ] Fonts: display strategy set; preloads limited to above-the-fold faces.
+
+## 4. Main Thread
+
+- [ ] Load trace: no task over the profile ceiling. Longest task: [ms, where].
+- [ ] The three primary interactions traced; handlers within INP budget.
+- [ ] Scroll/input listeners passive where they never prevent default.
+
+## 5. Stability & Loading States
+
+- [ ] Async content arrives into reserved space (dimensions/aspect-ratio verified).
+- [ ] Loading states: matched skeletons, failure and timeout paths render.
+- [ ] Degraded-network pass completed (cache disabled, declared throttle).
+
+## 6. Lifecycle
+
+- [ ] Repeat view: hashed assets from cache; repeat LCP beats first-view LCP.
+- [ ] Timers and observers owned: cleared on teardown, gated on `document.hidden`.
+- [ ] Long-lived pages: heap steady across ten minutes of representative use.
+
+## 📝 Open Items & Blockers
+
+[Every `[ ]` above that stays open at delivery is listed here with its reason and its owner — an unchecked item with no owner is a FAIL, not a note.]
+
+**Status:** [✅ PASS | ⚠️ CONDITIONAL — exceptions: PEX-… | ❌ FAIL]


### PR DESCRIPTION
Methodology v2, pre-registered **before any data collection**, replacing the v1 design that pasted the full core into the prompt — which defeats lazy loading and therefore measured something other than A11Y.md.

## What this adds

**Protocol** (`METHODOLOGY.md` v2.0, with version history):
- Four conditions: bare · generic request · **placebo standard** · A11Y.md. The decisive pre-registered contrast is D−B: does the standard beat one free sentence?
- Lazy loading tested faithfully: the model gets a single scoped `read_file` tool; which files it opens is itself a pre-registered outcome, classified as map / core-rule / template / unjustified.
- **Tokens as a co-primary outcome** — total per task, lazily-loaded bytes, cached share, tokens per violation avoided.
- Blinding (hash-renamed files, sealed mapping), pre-specified analysis plan, honest arms: the primary arm is the free-tier model, named in any report title; Claude/GPT are conditional extension arms.
- Pilot disclosure: one generation under a draft harness was discarded (its grounding sentence taught selective loading) and earned two design rules.

**Tasks** (`PROMPTS.md`): 3 → 10, from the WebAIM Million's recurring error categories, each mapped to the guide §2.1 should select. Prompts never mention accessibility; tasks 1–3 untouched from v1.

**Control standard** (`control-standard/`, 15 files): a real performance standard mirroring A11Y.md's anatomy — same section structure, same §2.1 map format, same templates, subject swapped. Size parity per task: core −3.5%, tasks −3.2%…−5.4%, bias direction declared. Word-boundary contamination sweep: clean. Construction rules and known asymmetries documented in `CONTROL.md`, deliberately outside the directory the model can read.

**Collector** (`collect.py`): stdlib-only, Gemini Interactions API, tool loop with scoped reads, per-call usage accounting, rate ceiling + daily cap + `--resume` for multi-day free-tier waves, raw responses persisted before parsing. Collected data never enters the repo (#32); it is destined for a DOI'd dataset.

## Before collection starts

The protocol will be registered at **OSF Registries** and the registration ID added in the same commit that opens collection. From that point, every departure is a dated entry in `DEVIATIONS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)