### PR TITLE
OSF registration osf.io/pg6r5 — collection opens

### DIFF
--- a/benchmark/DEVIATIONS.md
+++ b/benchmark/DEVIATIONS.md
@@ -1,0 +1,12 @@
+# Deviations from the pre-registered protocol
+
+> Every departure from [`METHODOLOGY.md`](METHODOLOGY.md) as registered ([osf.io/pg6r5](https://osf.io/pg6r5)), dated, with what changed and why. Deviations are documented, never hidden — that is the entire point of pre-registering. Newest first.
+
+---
+
+## 2026-08-16 — Protocol tag is annotated, not GPG-signed
+
+- **Registered text:** "The repository tag marking the frozen protocol is signed."
+- **What happened:** no GPG signing key is configured on the collection machine; the tag `benchmark-protocol-v2.0` was created annotated but unsigned.
+- **Why it does not weaken the freeze:** the tamper-evident anchor was never the tag — it is the OSF registration itself, which is immutable, timestamped by a third party, and carries the SHA-256 of every frozen file. The tag is a repository-side convenience pointer to the same tree.
+- **Remedy if it matters later:** a signed tag can be added over the same commit once a key exists; the hashes in the registration make any rewrite detectable either way.

--- a/benchmark/METHODOLOGY.md
+++ b/benchmark/METHODOLOGY.md
@@ -147,7 +147,7 @@ One generation (signup form, condition D) was run on 2026-08-16 under a draft ha
 
 ## Registration
 
-This protocol is registered at **OSF Registries** before the first retained generation, and the registration's identifier is added here in the same commit that starts collection. The repository tag marking the frozen protocol is signed. From that point, every departure — a model that refuses a task, a rate-limit change mid-wave, a re-collected cell — is a dated entry in `DEVIATIONS.md`.
+This protocol is registered at **OSF Registries: [osf.io/pg6r5](https://osf.io/pg6r5)** (registered 2026-08-16, before any retained generation). The registration snapshot carries the frozen files and their SHA-256 hashes as of commit `dcf199b` — the tree also marked by the repository tag [`benchmark-protocol-v2.0`](https://github.com/fecarrico/A11Y.md/releases/tag/benchmark-protocol-v2.0). **Collection opens with the commit that adds this paragraph.** From this point, every departure — a model that refuses a task, a rate-limit change mid-wave, a re-collected cell — is a dated entry in [`DEVIATIONS.md`](DEVIATIONS.md).
 
 ## Phase 2 — human validation (planned, not started)
 


### PR DESCRIPTION
The protocol promised its registration identifier would land in the same commit that opens collection. This is that commit.

- **Registration:** https://osf.io/pg6r5 — Open-Ended Registration, public, registered 2026-08-16, verified via the OSF API (title, template and summary match). The snapshot carries the frozen files and their SHA-256 hashes as of `dcf199b`, the tree also marked by the tag [`benchmark-protocol-v2.0`](https://github.com/fecarrico/A11Y.md/releases/tag/benchmark-protocol-v2.0).
- **`DEVIATIONS.md` opens today** with its first entry: the protocol tag is annotated, not GPG-signed (no signing key on the collection machine) — and why the freeze does not depend on it.

From here on, the protocol is something the repository answers to, not something it edits. Collection begins after this merge:

```bash
python3 benchmark/collect.py --conditions A,B,C,D --runs 10 --rpm 10 --daily-cap 60
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)