### PR TITLE
fix(benchmark): interleave conditions, as the registered protocol requires

### DIFF
--- a/benchmark/DEVIATIONS.md
+++ b/benchmark/DEVIATIONS.md
@@ -4,6 +4,13 @@
 
 ---
 
+## 2026-08-16 — Collector reordered to interleave conditions (before any retained generation)
+
+- **Registered text:** METHODOLOGY.md §Size — "waves are collected on consecutive days with conditions interleaved (never one condition's block on one day — interface drift must not load onto a condition)."
+- **What happened:** the frozen `collect.py` (SHA-256 `258cbfab…` in the registration) built its job list task → condition → run, which collects condition blocks — contradicting the registered text. Caught on the pre-collection `--plan` inspection; the job order now cycles every condition within each task before any condition repeats, runs outermost.
+- **Why it is a deviation and not an edit:** the collector's hash is part of the registered snapshot, so any change to it is logged here, even one that *restores* compliance with the registered methodology. The methodology text is normative; the instrument answers to it.
+- **Timing:** zero generations had been collected under the frozen ordering.
+
 ## 2026-08-16 — Protocol tag is annotated, not GPG-signed
 
 - **Registered text:** "The repository tag marking the frozen protocol is signed."

--- a/benchmark/collect.py
+++ b/benchmark/collect.py
@@ -446,9 +446,14 @@ def main() -> int:
                   file=sys.stderr)
             return 2
 
+    # Interleaved, as the registered protocol requires (METHODOLOGY.md §Size):
+    # within a wave, each task cycles through every condition before any
+    # condition repeats — a day's cap can never land on one condition's block,
+    # so interface drift cannot load onto a condition. Runs are the outermost
+    # layer: run 1 of the whole design completes before run 2 begins.
     jobs = [(task, condition, run)
-            for task in wanted for condition in conditions
-            for run in range(1, args.runs + 1)]
+            for run in range(1, args.runs + 1)
+            for task in wanted for condition in conditions]
 
     html_dir = args.out / "html"
     raw_dir = args.out / "raw"


### PR DESCRIPTION
The frozen `collect.py` built its job list task → condition → run — condition blocks, which METHODOLOGY.md §Size forbids in so many words. Caught on the pre-collection `--plan` inspection; **zero generations** were collected under the old ordering.

Now: every condition cycles within each task before any condition repeats, runs outermost. Verified:

```
signup-form A → B → C → D → modal A → B → C → D → …
```

Because the collector's hash is in the registered snapshot (osf.io/pg6r5), the change is logged as `DEVIATIONS.md` entry #2 even though it *restores* compliance: the methodology text is normative, the instrument answers to it.

Collection starts after this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)