### PR TITLE
Deviation #3 — primary arm lands on gemini-3.5-flash-lite

### DIFF
--- a/benchmark/DEVIATIONS.md
+++ b/benchmark/DEVIATIONS.md
@@ -4,6 +4,13 @@
 
 ---
 
+## 2026-08-16 — Primary-arm model finalized as `gemini-3.5-flash-lite` after a quota wall
+
+- **Registered text:** Arm 1 is "Gemini API, free tier (current Flash-class model; exact model string and version recorded per call)" — the registration deliberately did not pin a model string.
+- **What happened:** the first collection wave started on `gemini-3.6-flash` and hit its free-tier quota at 20 requests/day (AI Studio per-model table; every full-Flash model carries the same 20/day cap). The full design needs ~1,300 calls — two months at that cap. The Lite tier allows 500/day. The arm restarts on **`gemini-3.5-flash-lite`** (current stable Lite, 15 RPM / 500 RPD), verified working with the tool loop via `--probe` before this entry.
+- **Data handling:** 3 generations had been collected on `gemini-3.6-flash` (signup-form A, B, C of run 1). They are set aside under `runs/aside-gemini-3.6-flash/` as exploratory material and are **never pooled** with the primary arm. The primary arm's log starts clean.
+- **Effect on interpretation:** none beyond what the registration already declared — the model string is recorded per call and named in any report title. A Lite-class model arguably makes the test *harder* for the standard, not easier: smaller models depend more on the quality of their context.
+
 ## 2026-08-16 — Collector reordered to interleave conditions (before any retained generation)
 
 - **Registered text:** METHODOLOGY.md §Size — "waves are collected on consecutive days with conditions interleaved (never one condition's block on one day — interface drift must not load onto a condition)."

--- a/benchmark/collect.py
+++ b/benchmark/collect.py
@@ -36,7 +36,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 API_URL = "https://generativelanguage.googleapis.com/v1beta/interactions"
-DEFAULT_MODEL = "gemini-3.6-flash"
+DEFAULT_MODEL = "gemini-3.5-flash-lite"
 
 REPO = Path(__file__).resolve().parent.parent
 BENCH = REPO / "benchmark"


### PR DESCRIPTION
First wave hit `gemini-3.6-flash`'s free-tier wall: **20 requests/day** (AI Studio per-model table — every full-Flash model carries the same cap; the Lite tier carries **500/day**). The design needs ~1,300 calls: two months vs three days.

The registration pinned no model string on purpose — Arm 1 is "current Flash-class model; exact model string recorded per call" — so this finalizes the arm rather than changing it. Logged as `DEVIATIONS.md` entry #3 anyway, because the collector's default-model line is part of the frozen snapshot.

- `gemini-3.5-flash-lite` verified working with the tool loop via `--probe` (15 RPM / 500 RPD, quota untouched)
- The 3 generations collected on 3.6-flash set aside under `runs/aside-gemini-3.6-flash/`, never pooled
- Wave 1 restarts after this merge: `--rpm 12 --daily-cap 450`

🤖 Generated with [Claude Code](https://claude.com/claude-code)