### PR TITLE
Arm 2 wall clock 20 → 40 min — the agent does the whole protocol

### DIFF
--- a/benchmark/ARM2.md
+++ b/benchmark/ARM2.md
@@ -31,7 +31,9 @@ Arm 1 simulates lazy loading with a single scoped tool over a raw API. Arm 2 run
 claude -p "<task prompt, verbatim>" --output-format json --permission-mode acceptEdits
 ```
 
-run from inside the workspace, with a 20-minute wall clock per run. `acceptEdits` lets the agent write files without interactive approval; everything else stays at the product's defaults.
+run from inside the workspace, with a 40-minute wall clock per run. `acceptEdits` lets the agent write files without interactive approval; everything else stays at the product's defaults.
+
+> **Amendment, 2026-08-16 (before any retained D run):** the clock was declared at 20 minutes and calibrated blind. The first condition-D run exceeded it — not stalled, but **following the standard in full**: alongside the page it generated `REPORT.md` and `A11Y-DECISIONS.md` unprompted, exactly as the standard's Release Evidence rule mandates, and 20 minutes was not enough to finish. The clock is now 40 minutes, symmetric across conditions; the timed-out run re-collects. The behaviour itself — a real agent producing the lifecycle artifacts nobody asked for — is an ecological observation in its own right and will be reported.
 
 ## The environment is real, and that is declared, not sanitized
 

--- a/benchmark/arm2.py
+++ b/benchmark/arm2.py
@@ -35,7 +35,7 @@ from collect import load_tasks  # the same frozen prompts, the same parser
 
 TASKS = ("signup-form", "destructive-confirmation-modal", "dashboard-chart")
 CONDITIONS = ("A", "D")
-TIMEOUT_S = 20 * 60
+TIMEOUT_S = 40 * 60
 
 # Verbatim Quick Start rule, pointed at the local copy (ARM2.md §Workspaces).
 RULE = ("When developing the frontend, follow strictly the accessibility rules "


### PR DESCRIPTION
First condition-D run exceeded the 20-min clock. The capture shows why — this is the finding, not the failure:

```
criou: A11Y-DECISIONS.md, REPORT.md, app.js, index.html, styles.css
```

A real agent, given only the Quick Start rule in `CLAUDE.md`, **followed the Release Evidence rule unprompted**: generated the page *and* the lifecycle artifacts. Twenty minutes was calibrated blind against page generation; the standard makes the agent do more than generate a page.

Clock now 40 min, symmetric across conditions, amendment dated in `ARM2.md` before any retained D run. The timed-out run re-collects under `--resume`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)