### PR TITLE
Arm 2 gains a second agent — Codex CLI, declared first

### DIFF
--- a/benchmark/ARM2.md
+++ b/benchmark/ARM2.md
@@ -43,6 +43,21 @@ Claude Code loads the developer's user-level configuration (global `CLAUDE.md`, 
 
 Per run: every file the agent created (the seeded standard files are excluded by manifest), the largest HTML artifact (with locally-referenced CSS/JS inlined mechanically, the assembly rule the runbook already allows), the full `claude -p` response JSON verbatim (model, usage, reported cost), wall-clock duration, and the agent version. A run that produces no HTML is logged as such — that is data, not failure.
 
+## Second agent — Codex CLI (added 2026-08-17, before its first run)
+
+The arm extends to a second real agent under the same design: same three tasks, same conditions, same `n=3`, same 40-minute clock, same capture. What changes is only what the product itself changes:
+
+- **Client:** Codex CLI (version recorded per run), official non-interactive mode `codex exec`, authenticated by ChatGPT subscription sign-in — the product's documented path.
+- **Rule file:** condition D's rule goes in `AGENTS.md` — the config file Codex reads, and one the standard's own Quick Start already names.
+- **The one concession, translated:** `--sandbox workspace-write` (file writes without interactive approval — Codex's equivalent of `acceptEdits`) plus `--skip-git-repo-check` (the workspace is a fresh directory, not a git repository). `--json` streams the client's events, kept verbatim; token figures in them are client-reported and labeled as such.
+- **Quota:** the subscription tier's Codex allowance is the lightest sold; if a wave hits it, collection resumes in the next window — the same discipline as the primary arm's daily caps.
+
+Two agents do not make a model comparison and none will be drawn: each agent is reported against its own baseline (its condition A), descriptively, like everything else in this arm.
+
+### Capture notes (running log)
+
+- **2026-08-16, `claude-code__destructive-confirmation-modal__A__run2`:** the agent built the page but wrote it to its session scratchpad and attempted to publish it as a chat artifact instead of writing to the workspace. The file was recovered mechanically from the path named in the response JSON (kept under `runs/arm2/recovered/`, copied into the capture set). Observation worth reporting: every condition-D run anchored its output in the project directory; condition-A runs occasionally treated the task as chat. The standard appears to give the agent a sense of *place*.
+
 ## What will and will not be claimed
 
 Outputs are scored by the same pinned harness as Arm 1 and reported **descriptively, next to — never pooled with — the primary arm**. Eighteen runs support statements shaped like "the direction held" or "it did not"; they support no p-value and none will be computed. Token figures from this arm are *reported-by-the-client* numbers, not API-metered ones, and are labeled accordingly.

--- a/benchmark/arm2.py
+++ b/benchmark/arm2.py
@@ -41,12 +41,36 @@ TIMEOUT_S = 40 * 60
 RULE = ("When developing the frontend, follow strictly the accessibility rules "
         "defined in A11Y.md: ./A11Y.md\n")
 
+# Each agent is invoked through its official client's documented scripting mode,
+# reads the rule from the config file its product documents (both are named in
+# the standard's own Quick Start), and gets exactly one concession: permission
+# to write files without interactive approval. Everything else is the product's
+# default. Usage figures are whatever the client reports — labeled as such.
+AGENTS = {
+    "claude-code": {
+        "rule_file": "CLAUDE.md",
+        "version": ["claude", "--version"],
+        "command": lambda prompt: ["claude", "-p", prompt,
+                                   "--output-format", "json",
+                                   "--permission-mode", "acceptEdits"],
+        "parse": "json",    # stdout is one JSON object
+    },
+    "codex": {
+        "rule_file": "AGENTS.md",
+        "version": ["codex", "--version"],
+        "command": lambda prompt: ["codex", "exec", prompt, "--json",
+                                   "--sandbox", "workspace-write",
+                                   "--skip-git-repo-check"],
+        "parse": "jsonl",   # stdout is a stream of JSONL events
+    },
+}
+
 LINK_CSS = re.compile(r"<link\s+[^>]*rel=[\"']stylesheet[\"'][^>]*>", re.I)
 HREF = re.compile(r"href=[\"']([^\"']+)[\"']", re.I)
 SCRIPT_SRC = re.compile(r"<script\s+[^>]*src=[\"']([^\"']+)[\"'][^>]*>\s*</script>", re.I)
 
 
-def build_workspace(condition: str, parent: Path) -> tuple[Path, set[str]]:
+def build_workspace(condition: str, parent: Path, rule_file: str) -> tuple[Path, set[str]]:
     """Create a fresh workspace; return it and the seeded files' relative paths."""
     ws = Path(tempfile.mkdtemp(prefix=f"arm2-{condition}-", dir=parent))
     seeded: set[str] = set()
@@ -55,7 +79,7 @@ def build_workspace(condition: str, parent: Path) -> tuple[Path, set[str]]:
         shutil.copy2(src / "A11Y.md", ws / "A11Y.md")
         shutil.copytree(src / "references", ws / "references")
         shutil.copytree(src / "templates", ws / "templates")
-        (ws / "CLAUDE.md").write_text(RULE, encoding="utf-8")
+        (ws / rule_file).write_text(RULE, encoding="utf-8")
         seeded = {str(p.relative_to(ws)) for p in ws.rglob("*") if p.is_file()}
     return ws, seeded
 
@@ -102,12 +126,11 @@ def pick_html(files: list[dict], ws: Path) -> Path | None:
     return ws / max(candidates, key=lambda f: f["bytes"])["path"]
 
 
-def run_agent(task_prompt: str, ws: Path) -> tuple[dict | None, str, float]:
+def run_agent(agent: dict, task_prompt: str, ws: Path) -> tuple[dict | None, str, float]:
     started = time.monotonic()
     try:
         proc = subprocess.run(
-            ["claude", "-p", task_prompt,
-             "--output-format", "json", "--permission-mode", "acceptEdits"],
+            agent["command"](task_prompt),
             cwd=ws, capture_output=True, text=True, timeout=TIMEOUT_S,
         )
         raw = proc.stdout
@@ -116,20 +139,62 @@ def run_agent(task_prompt: str, ws: Path) -> tuple[dict | None, str, float]:
     elapsed = time.monotonic() - started
     if proc.returncode != 0:
         return None, f"exit {proc.returncode}: {proc.stderr[:300]}", elapsed
+
+    if agent["parse"] == "jsonl":
+        events, stray = [], []
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except json.JSONDecodeError:
+                stray.append(line)
+        response: dict = {"events": events}
+        if stray:
+            response["unparsed_lines"] = stray[:200]
+        # best-effort usage: the last event that carries token figures
+        for event in reversed(events):
+            found = _usage_in(event)
+            if found:
+                response["usage"] = found
+                break
+        return response, "", elapsed
+
     try:
         return json.loads(raw), "", elapsed
     except json.JSONDecodeError:
         return {"unparsed_stdout": raw[:20000]}, "stdout was not JSON", elapsed
 
 
+def _usage_in(node):
+    """Find a dict of token counts anywhere in an event, by shape."""
+    if isinstance(node, dict):
+        if any("token" in str(k).lower() for k in node) and \
+           any(isinstance(v, int) for v in node.values()):
+            return node
+        for value in node.values():
+            found = _usage_in(value)
+            if found:
+                return found
+    elif isinstance(node, list):
+        for item in node:
+            found = _usage_in(item)
+            if found:
+                return found
+    return None
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Run the ecological arm (ARM2.md).")
+    parser.add_argument("--agent", default="claude-code", choices=sorted(AGENTS))
     parser.add_argument("--runs", type=int, default=3)
     parser.add_argument("--plan", action="store_true")
     parser.add_argument("--resume", action="store_true")
     parser.add_argument("--keep-workspaces", action="store_true",
                         help="do not delete workspaces after capture (debugging)")
     args = parser.parse_args()
+    agent = AGENTS[args.agent]
 
     tasks = load_tasks(BENCH / "PROMPTS.md")
     missing = [t for t in TASKS if t not in tasks]
@@ -137,14 +202,14 @@ def main() -> int:
         print(f"error: tasks not found in PROMPTS.md: {missing}", file=sys.stderr)
         return 2
 
-    version = subprocess.run(["claude", "--version"], capture_output=True, text=True).stdout.strip()
+    version = subprocess.run(agent["version"], capture_output=True, text=True).stdout.strip()
 
     jobs = [(t, c, r) for r in range(1, args.runs + 1) for t in TASKS for c in CONDITIONS]
     html_dir, raw_dir = OUT / "html", OUT / "raw"
     log_path = OUT / "log.jsonl"
 
     def slug(t, c, r):
-        return f"claude-code__{t}__{c}__run{r}"
+        return f"{args.agent}__{t}__{c}__run{r}"
 
     if args.resume:
         jobs = [j for j in jobs if not (html_dir / f"{slug(*j)}.html").is_file()]
@@ -166,14 +231,14 @@ def main() -> int:
     for index, (task, condition, run) in enumerate(jobs, 1):
         name = slug(task, condition, run)
         print(f"[{index}/{len(jobs)}] {name}", flush=True)
-        ws, seeded = build_workspace(condition, scratch)
+        ws, seeded = build_workspace(condition, scratch, agent["rule_file"])
 
-        response, error, elapsed = run_agent(tasks[task], ws)
+        response, error, elapsed = run_agent(agent, tasks[task], ws)
         files = created_files(ws, seeded)
         html_path = pick_html(files, ws)
 
         record = {
-            "id": name, "task": task, "condition": condition, "run": run,
+            "id": name, "agent": args.agent, "task": task, "condition": condition, "run": run,
             "agent_version": version,
             "collected_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
             "duration_s": round(elapsed, 1),


### PR DESCRIPTION
Extends the ecological arm to a second real agent under the identical design (same tasks, conditions, n, clock, capture). Declared in `ARM2.md` **before its first run**, dated.

- **Codex CLI** via official `codex exec`, ChatGPT subscription sign-in (the product's documented path — same legitimacy as `claude -p`)
- Condition D rule in **`AGENTS.md`** — the file Codex reads, already named in the standard's Quick Start
- The one concession translated: `--sandbox workspace-write` ≈ `acceptEdits`; `--json` events kept verbatim, client-reported tokens labeled as such
- Runner grows an agent adapter; the Claude arm's 18/18 captures are untouched (`--resume` verified: 0 pending)
- Capture note logged: the scratchpad recovery + the "sense of place" observation (all D runs anchored in the project; A runs occasionally treated the task as chat)

No model comparison will be drawn — each agent reports against its own condition-A baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)