### PR TITLE
Headless verification — axe + screenshots in one pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ benchmark/.env
 benchmark/runs/
 
 __pycache__/
+
+# benchmark: headless verification — the one external dependency (Playwright),
+# contained here; the lockfile is committed, the installed tree is not.
+benchmark/verify/node_modules/

--- a/benchmark/verify/package-lock.json
+++ b/benchmark/verify/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "verify",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "verify",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "playwright": "^1.62.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/benchmark/verify/package.json
+++ b/benchmark/verify/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "verify",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "dependencies": {
+    "playwright": "^1.62.1"
+  }
+}

--- a/benchmark/verify/verify.js
+++ b/benchmark/verify/verify.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/**
+ * verify.js — headless verification: the pinned axe over every generation,
+ * a screenshot of each page as a by-product of the same pass.
+ *
+ * The instrument is the registered one: harness/axe.min.js, SHA-256-checked
+ * against axe.lock before anything runs. Pages are served over HTTP (file://
+ * changes how some pages behave) and mounted unmodified. Results append to a
+ * JSONL — one line per page, written before the next page loads, so a crash
+ * costs one page, never the batch.
+ *
+ *   node verify.js --dir ../runs/html --out ../runs/verify/axe.jsonl \
+ *                  --shots ../runs/verify/screenshots [--resume]
+ *
+ * Repeatable --dir. Only dependency: playwright (see package.json).
+ */
+
+const { chromium } = require('playwright');
+const crypto = require('crypto');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+
+function args() {
+  const a = { dirs: [], out: null, shots: null, resume: false, timeout: 30000 };
+  const v = process.argv.slice(2);
+  for (let i = 0; i < v.length; i++) {
+    if (v[i] === '--dir') a.dirs.push(path.resolve(v[++i]));
+    else if (v[i] === '--out') a.out = path.resolve(v[++i]);
+    else if (v[i] === '--shots') a.shots = path.resolve(v[++i]);
+    else if (v[i] === '--resume') a.resume = true;
+    else if (v[i] === '--timeout') a.timeout = parseInt(v[++i], 10);
+    else { console.error(`unknown arg: ${v[i]}`); process.exit(2); }
+  }
+  if (!a.dirs.length || !a.out) {
+    console.error('usage: node verify.js --dir DIR [--dir DIR2] --out FILE.jsonl [--shots DIR] [--resume]');
+    process.exit(2);
+  }
+  return a;
+}
+
+function checkAxe() {
+  const dir = path.resolve(__dirname, '..', 'harness');
+  const lock = fs.readFileSync(path.join(dir, 'axe.lock'), 'utf8');
+  const version = (lock.match(/version:\s*(\S+)/) || [])[1];
+  const expected = (lock.match(/sha256:\s*([0-9a-f]{64})/) || [])[1];
+  const source = fs.readFileSync(path.join(dir, 'axe.min.js'));
+  const actual = crypto.createHash('sha256').update(source).digest('hex');
+  if (actual !== expected) {
+    console.error(`axe.min.js does not match axe.lock (${actual} != ${expected})`);
+    process.exit(1);
+  }
+  return { source: source.toString('utf8'), version };
+}
+
+function serve(dirs) {
+  // /0/<file>, /1/<file> — one prefix per --dir, nothing else reachable.
+  return http.createServer((req, res) => {
+    const m = req.url.match(/^\/(\d+)\/(.+)$/);
+    const dir = m && dirs[Number(m[1])];
+    const file = dir && path.join(dir, decodeURIComponent(m[2]));
+    if (!file || !file.startsWith(dir) || !fs.existsSync(file)) {
+      res.writeHead(404).end();
+      return;
+    }
+    res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+    res.end(fs.readFileSync(file));
+  });
+}
+
+(async () => {
+  const a = args();
+  const axe = checkAxe();
+
+  const done = new Set();
+  if (a.resume && fs.existsSync(a.out)) {
+    for (const line of fs.readFileSync(a.out, 'utf8').split('\n')) {
+      if (line.trim()) done.add(JSON.parse(line).id);
+    }
+  }
+
+  const jobs = [];
+  a.dirs.forEach((dir, index) => {
+    for (const name of fs.readdirSync(dir).sort()) {
+      if (!/\.html?$/i.test(name)) continue;
+      const id = name.replace(/\.html?$/i, '');
+      if (!done.has(id)) jobs.push({ id, url: `/${index}/${name}`, dir });
+    }
+  });
+  console.log(`${jobs.length} page(s) to verify · axe ${axe.version} (SHA ok)` +
+              (done.size ? ` · ${done.size} already done` : ''));
+  if (!jobs.length) process.exit(0);
+
+  fs.mkdirSync(path.dirname(a.out), { recursive: true });
+  if (a.shots) fs.mkdirSync(a.shots, { recursive: true });
+
+  const server = serve(a.dirs);
+  await new Promise(r => server.listen(0, '127.0.0.1', r));
+  const port = server.address().port;
+
+  const browser = await chromium.launch();
+  const context = await browser.newContext({ viewport: { width: 1280, height: 900 } });
+
+  let failures = 0;
+  for (const [i, job] of jobs.entries()) {
+    const started = Date.now();
+    const record = { id: job.id, axe_version: axe.version,
+                     verified_at: new Date().toISOString() };
+    const page = await context.newPage();
+    try {
+      await page.goto(`http://127.0.0.1:${port}${job.url}`,
+                      { waitUntil: 'load', timeout: a.timeout });
+      await page.waitForTimeout(500); // settle: entry animations, initial JS
+      await page.addScriptTag({ content: axe.source });
+      const result = await page.evaluate(async () =>
+        await axe.run(document, { resultTypes: ['violations'] }));
+
+      const counts = { critical: 0, serious: 0, moderate: 0, minor: 0 };
+      record.violations = result.violations.map(v => ({
+        id: v.id, impact: v.impact, nodes: v.nodes.length,
+      }));
+      for (const v of result.violations) {
+        if (counts[v.impact] !== undefined) counts[v.impact] += v.nodes.length;
+      }
+      record.counts = counts;
+
+      if (a.shots) {
+        const shot = path.join(a.shots, `${job.id}.png`);
+        await page.screenshot({ path: shot, fullPage: true });
+        record.screenshot = path.basename(shot);
+      }
+    } catch (error) {
+      failures++;
+      record.error = String(error).slice(0, 300);
+    } finally {
+      await page.close();
+    }
+    record.ms = Date.now() - started;
+    fs.appendFileSync(a.out, JSON.stringify(record) + '\n');
+    const c = record.counts;
+    console.log(`[${i + 1}/${jobs.length}] ${job.id}` + (record.error
+      ? `  ERROR ${record.error.slice(0, 60)}`
+      : `  crit ${c.critical} · serious ${c.serious} · mod ${c.moderate} · minor ${c.minor}`));
+  }
+
+  await browser.close();
+  server.close();
+  console.log(`\ndone · ${jobs.length} page(s) · ${failures} error(s) · ${a.out}`);
+  process.exit(failures ? 1 : 0);
+})();


### PR DESCRIPTION
Drives the registered instrument (`harness/axe.min.js`, SHA-256-checked against `axe.lock` at startup) over every generation in headless Chromium — pages served over HTTP, mounted unmodified, one JSONL record appended per page. Replaces the click-Run-all browser flow for batch scoring; the browser harness stays for interactive inspection.

**Screenshots of every generation fall out of the same pass free** — the side-by-side visual material (same task, with/without the standard).

- First external dependency (Playwright), contained in `benchmark/verify/` — lockfile committed, `node_modules` ignored. The standard stays portable markdown; this is harness.
- `--resume` skips already-verified pages; a crash costs one page, never the batch.
- Smoke test on six arm-2 pages: 0 errors, instrument discriminates (bare dashboard: 11 serious; grounded sibling: 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)