### PR TITLE
Antigravity: ambient-memory contamination — documented, remedied, gated

### DIFF
--- a/benchmark/ARM2.md
+++ b/benchmark/ARM2.md
@@ -87,6 +87,15 @@ the motivation and the probes. Same tasks, same conditions, same n, same clock.
   one JSON object (`status`, `response`, `duration_seconds`, `num_turns`,
   `usage`) — recorded as reported, labeled as the client's own accounting.
 
+**Amendment (2026-08-18, before any retained run) — fresh profile required.**
+The first collection attempt was aborted after two failed runs: the product's
+persistent profile memory carried the standard into a bare-condition session
+(condition A citing A11Y.md unprompted — full account in `DEVIATIONS.md`).
+The cell therefore collects under a fresh OS profile (`HOME` at an empty
+directory, one-time auth) with `--new-project` per run, gated on a
+clean-profile probe that must show no ambient knowledge of the standard.
+If the probe fails, the extension is abandoned and documented.
+
 **Amendment — the arm's honest formulation (2026-08-18).** With no cell shared
 with Arm 1, this arm does not "check that the Arm 1 effect survives a real
 agent". What it shows is: *an independent demonstration, in real agents, that

--- a/benchmark/DEVIATIONS.md
+++ b/benchmark/DEVIATIONS.md
@@ -4,6 +4,14 @@
 
 ---
 
+## 2026-08-18 — Antigravity: first attempt aborted; ambient-memory contamination found; fresh profile required
+
+- **What happened:** the first two runs (signup-form, conditions A and D, run 1) ended `status=ERROR` with zero files created — and their transcripts show something worse than a flag problem: **condition A went looking for A11Y.md.** The agent resolved paths inside the author's repository and cited the standard, WCAG 2.2 AA and the author's own UX rules — in a fresh workspace, on a bare task prompt that carried no rule at all.
+- **Where it comes from:** Antigravity keeps persistent profile-level memory and product-level rules. A follow-up probe **with `--new-project`** (outside the dataset) still described a brand-new empty directory as "structured around accessibility guidelines (A11y)" and cited `docs/en/A11Y.md` by path. On the standard author's machine the standard is *ambient* — the product carries it into sessions that never asked for it. An A cell collected in that profile would not be an A cell.
+- **Why this differs from the other agents:** the audit entry below documents that the live profile's global agent config contains zero accessibility content for Claude Code and Codex — running them in the live environment is "declared, not sanitized" working as intended. For Antigravity the live environment contains **the treatment itself**; that philosophy cannot cover it.
+- **Declared remedy (before any retained run):** the Antigravity cell collects under a **fresh OS profile** — `HOME` pointed at an empty directory, one-time authentication, locally verified to isolate profile state — with `--new-project` added to every invocation. The asymmetry with the other two agents is declared here. **Gate:** a clean-profile probe must answer "what do you know about this project?" without referencing the standard; if ambient knowledge survives a fresh profile (server-side memory), the extension is **abandoned, and this entry closes with that outcome** — a declared, unexecuted extension with its reason on record.
+- **Data handling:** the two ERROR runs stay in the collection log as failed records (precedent: the truncated Arm 1 cell). Nothing was produced, nothing is retained; `--resume` recollects them under the fixed invocation.
+
 ## 2026-08-18 — Third agent for the ecological arm: Antigravity CLI (declared before any run; motivated by results)
 
 - **What is added:** a third agent in Arm 2 — the Antigravity CLI (`agy`), official Google client, included in the author's existing Google AI Pro subscription ($0 marginal, the same criterion that qualified Claude Code and Codex). Same three tasks, same conditions A and D, same n=3, same 40-minute clock: 18 runs.

--- a/benchmark/arm2.py
+++ b/benchmark/arm2.py
@@ -74,7 +74,8 @@ AGENTS = {
                                    "--effort", "low",
                                    "--output-format", "json",
                                    "--mode", "accept-edits",
-                                   "--print-timeout", "40m"],
+                                   "--print-timeout", "40m",
+                                   "--new-project"],
         "parse": "json",    # stdout is one JSON object
     },
 }


### PR DESCRIPTION
The first two runs errored with zero files — and condition A cited A11Y.md unprompted: the author's Antigravity profile carries the standard as ambient memory, and `--new-project` alone does not shed it (probe logged in the DEVIATIONS entry). Remedy, declared **before any retained run**: collection under a fresh OS profile (empty `HOME`, one-time auth) with `--new-project` per invocation, gated on a clean-profile probe that must show no knowledge of the standard — otherwise the extension is abandoned and the entry closes saying so.

🤖 Generated with [Claude Code](https://claude.com/claude-code)