### PR TITLE
Study 2 registered: osf.io/mqs7x — agents named, collection opens on merge

### DIFF
--- a/benchmark/study2/DEVIATIONS.md
+++ b/benchmark/study2/DEVIATIONS.md
@@ -4,6 +4,16 @@
 > registered protocol, dated, clarifications included, nothing hidden. Newest
 > first.
 
-*No entries — there is nothing to deviate from until the protocol is
-registered. Pre-registration changes are ordinary drafting and live in git
-history.*
+## 2026-08-20 — Registration accepted; agents named; pre-declared fill-ins applied
+
+- **Registration:** [osf.io/mqs7x](https://osf.io/mqs7x), accepted 2026-08-20.
+  Snapshot audited on acceptance day: `study2/` files 6/6 bit-identical to the
+  frozen hashes.
+- **Agents named**, per §Engines' declared rule (available quota): **Claude
+  Code** (2.1.233 at naming) and **Codex CLI** (0.147.0). **Antigravity stays
+  as declared reserve** — it enters only if a quota wall forces a swap, with
+  its own dated entry, under Study 1's fresh-profile amendment.
+- **Fill-ins applied, not deviations:** the registration URL written into
+  §Registration and the README status boxes — both pre-declared as fill-ins by
+  the protocol itself. The frozen snapshot proves this journal started empty.
+- **Collection opens** with the merge of this entry. First wave: Claude Code.

--- a/benchmark/study2/PROTOCOL.md
+++ b/benchmark/study2/PROTOCOL.md
@@ -176,11 +176,14 @@ Study 1's discipline: dated entries, clarifications included, nothing hidden.
 
 ## Registration
 
-To be registered on OSF as **its own registration** — not an amendment to
-[osf.io/pg6r5](https://osf.io/pg6r5) — after the pilot freezes the classifier
-and **before Study 1 is published**, so that Study 1's limitations section
-points at a live public test instead of a promise. This section receives the
-registration URL when it exists.
+**Registered: [osf.io/mqs7x](https://osf.io/mqs7x)** — "A11Y.md Efficacy
+Benchmark (Study 2)", Open-Ended Registration, submitted 2026-08-19 01:29 UTC,
+accepted 2026-08-20, public. Its own registration — not an amendment to
+[osf.io/pg6r5](https://osf.io/pg6r5) — and registered **before Study 1's
+publication**, as this section always required. The snapshot's `study2/`
+folder was verified file-by-file against the frozen hashes (6/6 identical)
+on acceptance day. *(This paragraph is the fill-in this section pre-declared;
+the frozen snapshot carries the pre-registration wording.)*
 
 ## What will and will not be claimed
 

--- a/benchmark/study2/README.md
+++ b/benchmark/study2/README.md
@@ -18,7 +18,7 @@ in one real agent session** — the regime the standard was built for.
 - [x] Protocol drafted (2026-08-18)
 - [x] Pilot run and discarded; lessons written into the protocol (2026-08-18)
 - [x] Classifier frozen (SHA-256 in `CLASSIFIER.md`, 2026-08-18)
-- [ ] Registered on OSF (own registration — **before Study 1 publishes**)
+- [x] Registered on OSF: [osf.io/mqs7x](https://osf.io/mqs7x) (2026-08-20 — before Study 1 publishes)
 - [ ] Collection
 - [ ] Report
 


### PR DESCRIPTION
Acceptance-day audit: snapshot `study2/` folder 6/6 bit-identical to the frozen hashes; registration public, own ID, distinct title. Agents named per the registered quota rule (Claude Code + Codex; Antigravity reserve). §Registration receives its pre-declared URL fill-in. **Merging this opens collection — wave 1 (Claude Code, 15 journeys) starts right after.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)