### PR TITLE
Study 2: Codex quota wall — pre-declared reserve swap (Antigravity)

### DIFF
--- a/benchmark/study2/DEVIATIONS.md
+++ b/benchmark/study2/DEVIATIONS.md
@@ -4,6 +4,30 @@
 > registered protocol, dated, clarifications included, nothing hidden. Newest
 > first.
 
+## 2026-08-20 — Codex quota wall: the pre-declared reserve swap executes
+
+- **What happened:** all 15 Codex journey runs failed in seconds with the
+  client's own message: *"You've hit your usage limit … or try again at
+  Sep 16th, 2026"*. The plan's Codex quota — consumed in part by Study 1's
+  ecological runs — resets only in a month; waiting is not viable and was
+  never required.
+- **What executes:** the naming entry above pre-declared exactly this: the
+  reserve agent (Antigravity) enters **only if a quota wall forces the swap,
+  with its own dated entry** — this is that entry. No new decision is being
+  made; a declared rule is being applied on its declared trigger.
+- **Conditions of the swap:** Study 1's fresh-profile amendment applies in
+  full — empty-`HOME` profile, `--new-project` per run, and the clean-profile
+  gate probe re-run **before any retained journey** (the profile has since
+  hosted Study 1's Antigravity runs; if ambient knowledge of the standard
+  survives, collection halts and this entry reopens with that outcome).
+  Rule delivery for condition D: verbatim Quick Start as prompt preamble,
+  standard on disk — the bridge-cell translation already declared in ARM2.md.
+- **Data handling:** the 15 failed Codex records stay in the collection log
+  as failed records (Study 1 precedent); `--resume` never confuses them with
+  journeys, which key by agent. If Codex quota returns before Study 2 closes,
+  its 15 journeys may still be collected under the original naming — additive,
+  declared here in advance.
+
 ## 2026-08-20 — Registration accepted; agents named; pre-declared fill-ins applied
 
 - **Registration:** [osf.io/mqs7x](https://osf.io/mqs7x), accepted 2026-08-20.

--- a/benchmark/study2/run.py
+++ b/benchmark/study2/run.py
@@ -44,9 +44,21 @@ AGENTS = {
                                    "--sandbox", "workspace-write",
                                    "--skip-git-repo-check"],
     },
-    # Declared reserve (DEVIATIONS.md naming entry): antigravity — fresh
-    # profile + --new-project per Study 1's dated amendment, added here only
-    # if a quota wall forces the swap, with its own dated entry.
+    # Reserve, activated 2026-08-20 by the Codex quota wall (DEVIATIONS.md):
+    # fresh profile (empty HOME, set by the invoker) + --new-project per run,
+    # rule as prompt preamble per ARM2.md's bridge-cell translation.
+    "antigravity": {
+        "rule_file": None,
+        "prompt_rule": True,
+        "version": ["agy", "--version"],
+        "command": lambda prompt: ["agy", "-p", prompt,
+                                   "--model", "gemini-3.5-flash",
+                                   "--effort", "low",
+                                   "--output-format", "json",
+                                   "--mode", "accept-edits",
+                                   "--print-timeout", "90m",
+                                   "--new-project"],
+    },
 }
 
 
@@ -62,7 +74,8 @@ def build_workspace(condition: str, parent: Path, rule_file: str):
         shutil.copy2(src / "A11Y.md", ws / "A11Y.md")
         shutil.copytree(src / "references", ws / "references")
         shutil.copytree(src / "templates", ws / "templates")
-        (ws / rule_file).write_text(RULE, encoding="utf-8")
+        if rule_file:
+            (ws / rule_file).write_text(RULE, encoding="utf-8")
     seeded = {str(p.relative_to(ws)) for p in ws.rglob("*") if p.is_file()}
     return ws, seeded
 
@@ -98,6 +111,8 @@ def main() -> int:
         print(f"[{i}/{len(jobs)}] {name}", flush=True)
         ws, seeded = build_workspace(condition, scratch, agent["rule_file"])
         full = (GENERIC + prompt) if condition == "B" else prompt
+        if condition == "D" and agent.get("prompt_rule"):
+            full = RULE + "\n" + full
         t0 = time.time()
         try:
             r = subprocess.run(agent["command"](full), cwd=ws, capture_output=True,


### PR DESCRIPTION
The 15 Codex journeys failed instantly on the plan's usage limit (client message logged; reset Sep 16). The registered naming entry pre-declared this exact trigger and this exact remedy: the reserve agent enters, fresh profile + `--new-project`, clean-profile gate re-run before any retained journey. Merging under the author's standing instruction of 2026-08-20 ("pode seguir até finalizar as baterias") — executing a pre-declared rule, not making a new decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)