### PR TITLE
SC 2.5.8 adjudication pre-pass: measure by machine, judge by human

### DIFF
--- a/benchmark/DEVIATIONS.md
+++ b/benchmark/DEVIATIONS.md
@@ -4,6 +4,23 @@
 
 ---
 
+## 2026-08-23 — SC 2.5.8 adjudication: the registered machine/human split, applied
+
+- **Registered text:** MANUAL checklist items are *"automated where a scripted
+  browser can decide them; the remainder adjudicated by a human."*
+- **What ran:** `verify/target-prepass.js` measured every visible interactive
+  target on the 60 blind-sampled pages (Playwright, 1280×900). "No target
+  below 24×24 CSS px exists" is machine-decidable: **41 of 52 target-size rows
+  closed mechanically as N-A**, each stamped as such in the worksheet's
+  observation column. The 11 pages that do contain sub-24px targets go to the
+  human adjudicator with a factual measurement report
+  (`adjudicacao-alvos-pequenos.md` — shapes, counts, examples); the exception
+  judgments the SC delegates to a person (equivalent control, inline,
+  essential) remain human, exactly as registered.
+- **Blinding intact:** the script sees content hashes, never conditions; the
+  sealed map stays sealed. Modal-focus rows are untouched — keyboard
+  interaction with focus-return judgment stays with the adjudicator.
+
 ## 2026-08-18 — Antigravity: first attempt aborted; ambient-memory contamination found; fresh profile required
 
 - **What happened:** the first two runs (signup-form, conditions A and D, run 1) ended `status=ERROR` with zero files created — and their transcripts show something worse than a flag problem: **condition A went looking for A11Y.md.** The agent resolved paths inside the author's repository and cited the standard, WCAG 2.2 AA and the author's own UX rules — in a fresh workspace, on a bare task prompt that carried no rule at all.

--- a/benchmark/verify/target-prepass.js
+++ b/benchmark/verify/target-prepass.js
@@ -1,0 +1,81 @@
+/**
+ * target-prepass.js — mechanical half of the SC 2.5.8 MANUAL items.
+ *
+ * The registered protocol: "automated where a scripted browser can decide
+ * them; the remainder adjudicated by a human." A scripted browser CAN decide
+ * "no interactive target below 24×24 CSS px exists on this page"; it CANNOT
+ * decide the exception judgments (equivalent control, inline, essential).
+ * This script measures every visible interactive target on every adjudication
+ * page and reports, per page, the sub-24px targets grouped by shape — the
+ * human judges exceptions only where small targets actually exist.
+ *
+ *   node target-prepass.js --dir <pages> --out <json>
+ */
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const args = process.argv.slice(2);
+function arg(name, dflt) {
+  const i = args.indexOf(name);
+  return i >= 0 ? args[i + 1] : dflt;
+}
+const dir = path.resolve(arg('--dir'));
+const out = path.resolve(arg('--out'));
+
+const SELECTOR = [
+  'a[href]', 'button', 'input:not([type=hidden])', 'select', 'textarea',
+  'summary', '[onclick]', '[tabindex]:not([tabindex="-1"])',
+  '[role=button]', '[role=link]', '[role=checkbox]', '[role=radio]',
+  '[role=tab]', '[role=menuitem]', '[role=option]', '[role=switch]',
+].join(',');
+
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage({ viewport: { width: 1280, height: 900 } });
+  const report = {};
+  const files = fs.readdirSync(dir).filter(f => /\.html?$/i.test(f)).sort();
+  for (const f of files) {
+    const url = 'file://' + path.join(dir, f);
+    const entry = { targets: 0, small: [], error: null };
+    try {
+      await page.goto(url, { waitUntil: 'load', timeout: 30000 });
+      await page.waitForTimeout(400); // JS de construção da página
+      const found = await page.evaluate((sel) => {
+        const seen = new Set();
+        const rows = [];
+        for (const el of document.querySelectorAll(sel)) {
+          if (seen.has(el)) continue;
+          seen.add(el);
+          const cs = getComputedStyle(el);
+          if (cs.display === 'none' || cs.visibility === 'hidden') continue;
+          const r = el.getBoundingClientRect();
+          if (r.width === 0 || r.height === 0) continue;
+          const label = (el.getAttribute('aria-label') || el.textContent || el.value || '')
+            .trim().replace(/\s+/g, ' ').slice(0, 40);
+          const inline = cs.display.startsWith('inline') && el.closest('p,li,td,figcaption') !== null;
+          rows.push({ tag: el.tagName.toLowerCase(), w: Math.round(r.width),
+                      h: Math.round(r.height), label, inline });
+        }
+        return rows;
+      }, SELECTOR);
+      entry.targets = found.length;
+      const groups = {};
+      for (const t of found) {
+        if (t.w >= 24 && t.h >= 24) continue;
+        const key = `${t.tag} ${t.w}×${t.h}${t.inline ? ' (inline em texto)' : ''}`;
+        groups[key] = groups[key] || { count: 0, exemplo: t.label };
+        groups[key].count++;
+      }
+      entry.small = Object.entries(groups)
+        .map(([shape, g]) => ({ shape, count: g.count, exemplo: g.exemplo }));
+    } catch (e) {
+      entry.error = String(e).slice(0, 200);
+    }
+    report[f] = entry;
+    const n = entry.small.reduce((s, g) => s + g.count, 0);
+    console.log(`${f}  alvos:${entry.targets}  sub-24px:${n}${entry.error ? '  ERRO' : ''}`);
+  }
+  await browser.close();
+  fs.writeFileSync(out, JSON.stringify(report, null, 1));
+})();


### PR DESCRIPTION
Applies the registered sentence — *automated where a scripted browser can decide them* — to the target-size MANUAL items: 41/52 rows machine-closed as N-A (no sub-24px target on the page), 11 pages remain for human exception judgment with a ready-made measurement report. Modal-focus rows untouched. Blinding intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)