### PR TITLE
fix(study2): analyzer double-counted Antigravity tokens — defect #4, dual reporting

### DIFF
--- a/benchmark/study2/DEVIATIONS.md
+++ b/benchmark/study2/DEVIATIONS.md
@@ -4,6 +4,36 @@
 > registered protocol, dated, clarifications included, nothing hidden. Newest
 > first.
 
+## 2026-08-24 — Instrument defect #4: the analyzer double-counted Antigravity token usage; analysis re-run, both outputs preserved
+
+- **Discovery:** during an author-requested external scrutiny of the full body
+  of work, the author asked whether the report's token table counted per screen
+  or per whole journey. Tracing that table's provenance against `analysis.json`
+  exposed a factor-of-two mismatch — the fourth instrument defect, and the
+  fourth found by human contact with the object rather than by any log: three
+  by eye on the screens, this one by a question in front of a table.
+- **The defect:** `analyze.py` summed every usage field whose name contains
+  "token". The Antigravity client reports `total_tokens` (= input + output)
+  **alongside** its components, so input and output were counted twice:
+  `fresh_per_screen` and `total_per_screen` were inflated ≈2× for every
+  Antigravity journey. The Claude Code schema has no aggregate field and was
+  unaffected (verified: identical values under both computations). Consistency,
+  axe and governance outcomes never touch these fields — the defect is confined
+  to the token metrics of one agent.
+- **Why the conclusions survive:** the inflation is uniform across conditions
+  (same client, same schema on every journey), so directions, ratios and
+  Cliff's deltas are unchanged; medians and interval endpoints halve. The
+  report's token table (21k / 19k / 41k fresh tokens per screen) had been
+  computed from the raw fields directly and is confirmed correct by the re-run.
+- **Remedy:** explicit per-schema field lists in `analyze.py` (dated comment in
+  code); the inflated output is preserved at
+  `runs/study2/analysis-token-double-count.json` and the corrected
+  `analysis.json` replaces it — dual reporting, the discipline of defects
+  #1–#3 applied a fourth time.
+- **Dataset:** v2 of the Zenodo record carries the inflated `analysis.json`;
+  the next dataset version will carry the corrected file and cite this entry
+  in its version notes. Nothing is overwritten, everything stays traceable.
+
 ## 2026-08-24 — Dataset v2 published (10.5281/zenodo.22080079)
 
 The corrected Study-2 verification is live as version 2 of the dataset record:

--- a/benchmark/study2/analyze.py
+++ b/benchmark/study2/analyze.py
@@ -49,10 +49,21 @@ def outcomes(rec):
         if "counts" in v:
             axe += v["counts"]["critical"] + v["counts"]["serious"]
     u = json.loads((S2 / "raw" / f"{rid}.json").read_text() or "{}").get("usage", {})
-    total = sum(v for k, v in u.items() if isinstance(v, int) and "token" in k)
-    cache = u.get("cache_read_input_tokens", u.get("cache_read_tokens", 0))
+    # 2026-08-24, instrument defect #4 (DEVIATIONS.md): the previous version
+    # summed every usage field containing "token". The Antigravity client
+    # reports total_tokens (= input + output) ALONGSIDE its components, so
+    # input and output were counted twice — every Antigravity token figure
+    # inflated ~2x. Explicit per-schema field lists; Claude Code unchanged.
+    if "total_tokens" in u:  # antigravity client schema
+        cache = u.get("cache_read_tokens", 0)
+        fresh = (u.get("input_tokens", 0) + u.get("output_tokens", 0)
+                 + u.get("thinking_tokens", 0))
+    else:                    # claude-code client schema
+        cache = u.get("cache_read_input_tokens", 0)
+        fresh = (u.get("input_tokens", 0) + u.get("output_tokens", 0)
+                 + u.get("cache_creation_input_tokens", 0))
     return {"excess": excess, "axe": axe,
-            "total_per_screen": total / 7, "fresh_per_screen": (total - cache) / 7}
+            "total_per_screen": (fresh + cache) / 7, "fresh_per_screen": fresh / 7}
 
 def topology(rid):
     rules = {}


### PR DESCRIPTION
## O que aconteceu

Durante o escrutínio pedido pelo autor, a pergunta "a Tabela de tokens é por tela ou por jornada?" levou à auditoria de proveniência dos números — e ela expôs um fator de 2 entre o relatório e o `analysis.json` registrado.

**O defeito:** `analyze.py` somava todo campo de usage contendo "token". O cliente do Antigravity reporta `total_tokens` (= input + output) **ao lado** dos componentes, então input e output eram contados duas vezes: todas as métricas de tokens do Antigravity saíram infladas ~2× no `analysis.json` publicado no dataset v2. O esquema do Claude Code não tem campo agregado — verificado idêntico nas duas contas.

**O que sobrevive:** tudo. A inflação é uniforme entre condições, então direções, razões e Cliff's deltas não mudam; medianas e intervalos caem pela metade. Os números do relatório (21/19/41 mil por tela) tinham sido computados direto dos campos brutos e a re-execução os confirma corretos.

**Disciplina:** quarto defeito de instrumento, quarta vez o mesmo rito — conserto datado no código, saída inflada preservada em `runs/study2/analysis-token-double-count.json`, análise regerada (consistência, axe e topologia bit-idênticos), entrada datada no DEVIATIONS.md do Estudo 2. A próxima versão do dataset carrega o arquivo corrigido citando a entrada.

E o placar segue: quatro defeitos, os quatro achados por contato humano com o objeto — três pelo olho nas telas, este por uma pergunta diante de uma tabela.

🤖 Generated with [Claude Code](https://claude.com/claude-code)