### PR TITLE
docs: READMEs apontam para o relato completo dos estudos no site

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Inside, you will find:
 - **The Command Center:** How the core `A11Y.md` file works.
 - **Anti-patterns & Protocol:** Real-world examples of AI hallucinations being fixed.
 - **Reference Library:** The taxonomy of the 29 engineering guides.
-- **Evidence & Research:** The field data the standard responds to — published benchmarks and studies, with sources.
+- **Evidence & Research:** The field data the standard responds to — published benchmarks and studies, with sources. Including the project's own preregistered efficacy benchmark (two studies, placebo-controlled, open data, honest nulls): **[read the full report](https://fecarrico.github.io/a11ymd/estudo/)**.
 - **Governance & Compliance:** Preparing for VPATs and formal audits.
 
 ---

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -66,7 +66,7 @@ Lá dentro você encontrará:
 - **O Command Center:** Como o arquivo principal A11Y.md funciona.
 - **Anti-patterns & Protocol:** Casos reais de alucinações de IA sendo corrigidas nativamente.
 - **Reference Library:** A taxonomia dos 29 guias de engenharia.
-- **Evidence & Research:** Os dados de campo aos quais o padrão responde — benchmarks e estudos publicados, com fontes.
+- **Evidence & Research:** Os dados de campo aos quais o padrão responde — benchmarks e estudos publicados, com fontes. Incluindo o benchmark de eficácia do próprio projeto (dois estudos pré-registrados, com placebo, dados abertos e empates publicados sem desconto): **[leia o relato completo](https://fecarrico.github.io/a11ymd/estudo/)**.
 - **Governança & Compliance:** Preparação técnica para auditorias formais.
 
 ---


### PR DESCRIPTION
O bullet da Evidence & Research nos dois READMEs ganha o link do relato completo — o benchmark de eficácia do próprio projeto, na página permanente do site.

**Ordem de merge:** depois de [a11ymd#25](https://github.com/fecarrico/a11ymd/pull/25) e do deploy do Pages, para o link nascer vivo. A seção correspondente da wiki (Evidence & Research) já está editada localmente em `WIKI/` — pasta fora do git por desenho — e publica via `deploy-wiki.sh` na mesma hora.

🤖 Generated with [Claude Code](https://claude.com/claude-code)