### PR TITLE
Release v2.0.0 — the post-benchmark milestone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2026-08-26
+
+The post-benchmark milestone. Everything below was shaped by three inputs: the project's own preregistered studies (what the numbers ordered), a measured token-economy pass (what the evidence allowed), and the Brazilian normative layer (what ABNT NBR 17225:2025 requires). Obligations grew 62 → 71 per edition while the cost per task stayed within 1.5% of the 1.8.0 floor — the diet paid for the growth.
+
 ### Added
 - **Benchmark harness (`benchmark/harness/` + `run-benchmark.py` + `RUNBOOK.md`):** the pre-registered methodology (2026-07-25) promised a static harness; it now exists, stdlib-only. `fetch-axe.py` vendors the pinned engine — **axe-core 4.13.0, SHA-256 locked in `axe.lock`** — so every run on any machine measures with the same engine. The harness mounts each generation unmodified in an iframe and runs axe plus the pre-registered deterministic checklist (clickable divs, label association, live region presence, 24px targets measured on the rendered DOM, ARIA Soup, and a semi-automated modal drive for task 2). `run-benchmark.py --analyze` prints the completeness check against the 54-cell design and the pre-registered analysis: median critical+serious per model and condition, zero-critical share, checklist pass-rate. The RUNBOOK fixes collection mechanics — fresh sessions, "Use your defaults." as the only permitted reply, interleaved conditions so interface drift cannot load one side, and a DEVIATIONS.md protocol. Validated end-to-end against a synthetic 54-run results file.
 - **Sources in `guide-generative-ui.md`:** the guide shipped in 1.7.0 with its claims uncited — the only guide outside the house citation pattern. Now anchored: WAI-ARIA `log` role and Sara Soueidan on live-region mechanics; a11ysupport.io's empirical test matrix for why token-streams behave differently per screen reader; ICCHP 2026 (Springer) on post-render verification of runtime-assembled UI; Hervás et al. 2026 (IJHCI) on cognitive load in generative interfaces.

--- a/docs/en/A11Y.md
+++ b/docs/en/A11Y.md
@@ -1,5 +1,5 @@
 # A11y Guidelines: Accessibility as a Baseline
-> **Version:** 1.8.0 | **Target Standard:** WCAG 2.2 AA | **Last Updated:** 2026-08-15
+> **Version:** 2.0.0 | **Target Standard:** WCAG 2.2 AA | **Last Updated:** 2026-08-26
 
 This document establishes the persistent context required so that the software **can be certified** under the **WCAG 2.2 AA**, **ISO 9241-171**, **ADA**, and **EAA** standards, depending on rigorous implementation and **mandatory human validation**.
 

--- a/docs/pt-BR/A11Y.md
+++ b/docs/pt-BR/A11Y.md
@@ -1,5 +1,5 @@
 # A11y Guidelines: Accessibility as a Baseline
-> **Versão:** 1.8.0 | **Padrão Alvo:** WCAG 2.2 AA | **Última Atualização:** 2026-08-15
+> **Versão:** 2.0.0 | **Padrão Alvo:** WCAG 2.2 AA | **Última Atualização:** 2026-08-26
 
 Este documento estabelece o contexto persistente necessário para que o software **possa ser certificado** segundo as normas **WCAG 2.2 AA**, **ISO 9241-171**, **ADA** e **EAA**, dependendo de implementação rigorosa e **validação humana obrigatória**.
 


### PR DESCRIPTION
## What this is

The release cut for **v2.0.0**: version headers in both editions and the CHANGELOG section, summarizing the six merged phases (#61–#66).

## The milestone in one table

| Axis | What shipped |
| :--- | :--- |
| Diet (bands A+B) | ~56 KB cut across the corpus; guide list deduplicated; content-interaction merged; zero obligations lost |
| Level A + NBR typography | Page Title, Language, Motion Actuation; 80ch line cap, typographic rhythm, start-aligned text |
| Brazil layer | NBR regular/plena ↔ Standard/Shield mapping; real Annex A; functional-performance section; sign-language guide (Hand Talk/VLibras); navigation rebuilt |
| Agentic web | Positioning in the right order; ARIA-for-agents named in ARIA Soup; Machine-Only Content Doors anti-pattern; new guide |
| Study mandates | contrast-check.py + computed-never-estimated rule; palette-definition protocol + trigger; Half-Climbed ARIA Ladders with kill criterion; double governance + interactive-states inventory |
| Net numbers | Obligations 62 → **71** per edition; cost within **+1.5%** of the 1.8.0 floor; linter PASS throughout |

## After merge (maintainer moves)

1. `git tag v2.0.0 && git push --tags` — one tag per version, per house rule.
2. The v2.0.0 tree is what the **round-2 benchmark freezes by hash** — phase 7 of the plan (preregistration of the consistency-ruler-v2 protocol, the diet non-regression check, and the ladder-class kill criterion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)