### PR TITLE
Round 2 protocol — drafted, not frozen (v1.8.0 × v2.0.0)

### DIFF
--- a/benchmark/round2/PROTOCOL-DRAFT.md
+++ b/benchmark/round2/PROTOCOL-DRAFT.md
@@ -1,0 +1,164 @@
+# Round 2 — the v2.0.0 audit (v1.8.0 × v2.0.0)
+
+> **DRAFT — not frozen, not registered.** This document follows the order of
+> operations Study 2 established: pilot (discarded) → ruler v2 frozen by hash →
+> OSF registration (its own registration) → collection. Nothing here binds
+> until the freeze; everything after the freeze binds via `DEVIATIONS.md`.
+
+## Why this round exists
+
+v2.0.0 was built from Study 2's findings and carries three public commitments
+([CHANGELOG](../../CHANGELOG.md), the published report):
+
+1. **Non-regression of the diet.** The release cut ~56 KB across the corpus in
+   two declared bands while *adding* 9 obligations (62 → 71 per edition). The
+   honest arithmetic (measured by `git ls-tree` between tags): −35.7 KB shrunk
+   in pre-existing files, +10.2 KB grown, +15.8 KB in new guides, −4.5 KB
+   deleted — **net corpus −9.7 KB, core +605 B**. The hypothesis to refute is
+   therefore not "less context, worse output"; it is **"adherence to the old
+   obligations fell during the rewrite"**. The outcome is per-obligation, not
+   volume.
+2. **The kill criterion.** Study 2's one half-climbed ARIA ladder
+   (`antigravity__journey__D__run3`: `aria-required-parent` 49 nodes +
+   `listitem` 49 + `aria-required-children` 7, one mold replicated across all
+   7 screens) must **disappear as a class**, not be patched per case.
+3. **The contrast bet.** Contrast failed in every uninstructed condition of
+   Study 2 and survived in 3 of 5 guided journeys. v2.0.0 moved contrast from
+   model reasoning to a deterministic protocol (computed-never-estimated,
+   palette-definition trigger). This round measures whether the bet paid.
+
+Study 1's `METHODOLOGY.md` §exploratory declared "Version delta — same tasks
+against a prior release of the standard" as an exploratory outcome. **This
+round promotes that outcome to primary**, and the registration must say so,
+citing the precedent.
+
+## Design
+
+- **Unit:** the frozen `bookstore-journey` (7 screens, one session, one
+  agent), prompt verbatim from [`../study2/PROMPTS.md`](../study2/PROMPTS.md).
+  Unchanged, for direct comparability with Round 1's 30 runs.
+- **Conditions (4):**
+  - **A** — bare (no instruction)
+  - **B** — generic (`Make it accessible.` prepended)
+  - **D18** — the standard at tag `v1.8.0`
+  - **D20** — the standard at tag `v2.0.0`
+  - No placebo, per Study 2's registered rationale (the placebo question is
+    answered; a journey costs hours). The slug keeps Study 2's 4-field shape
+    (`agent__journey__COND__runN`) so `run.py --resume`, `log.jsonl` and
+    `analyze.py` survive with label changes only.
+- **Workspace freezing:** condition workspaces are built from
+  `git archive <tag> -- docs/en`, never from the working tree. The
+  registration records, per condition, the SHA-256 of the archive's files
+  **concatenated in path order** — the same idiom Study 1 used for
+  `control-standard/`.
+- **Agents (2):** Claude Code and Antigravity, versions named at registration
+  (Round 1's clients no longer exist at those versions; Round 1 data is
+  context, never a pooled arm). Codex quota resets 2026-09-16; whether it
+  enters as a third agent is an **open question** below.
+- **n:** 5 per cell → `5 × 4 × 2 = 40 runs`. Cut rule inherited: if 40 proves
+  infeasible, agents are cut before repetitions.
+- **Clock:** 90 min per run, symmetric, inherited from Study 2's calibration.
+- **Blinding:** screen HTML renamed by hash with a sealed map before any human
+  look; governance artifacts counted by script, never read before adjudication.
+
+## Outcomes and the declared hierarchy (the ruler-v2 commitment)
+
+Study 2 published five rulers but ranked them post-hoc. Round 2 declares the
+hierarchy **before** collection, with the judge named per ruler:
+
+| # | Ruler | Serves | Judge | Status in code |
+| - | ----- | ------ | ----- | -------------- |
+| 1 | **Screens with error** (screen×error pairs) | the person navigating | axe (frozen) + script | to be frozen (was post-hoc) |
+| 2 | **Wrong decisions** (distinct error decisions) | the maintainer fixing | script over `verify/*.jsonl` | to be frozen (was hand-derived) |
+| 3 | **Clean journeys** (whole sites, zero violations) | the team shipping | script | to be frozen (was post-hoc) |
+| 4 | **Consistency v2** (see below) | the person relearning each screen | `classifier-v2.py` (frozen by hash) | to be built |
+| 5 | **Flagged elements** (raw node count) | the auditor | axe | frozen since Round 1 |
+
+Primary contrast: **D20 vs D18** on rulers 1–4. Secondary: D20 vs B, D20 vs A.
+Statistics inherited: seeded bootstrap (B=10,000), Cliff's delta, no p-values,
+never pooled across agents.
+
+### Per-obligation non-regression panel (commitment 1)
+
+The floor is what Round 1 already banked, checked per class, per condition:
+
+- `image-alt` and `label` classes: **zero across all D20 journeys** (Round 1
+  zeroed them in D; they must stay zero).
+- `color-contrast`: Round 1 had it in 3 of 5 D journeys — under the v2.0.0
+  deterministic protocol the target is **fewer affected journeys than D18**,
+  measured same-agent.
+- Governance pair (REPORT + DECISIONS): **10/10 in D20** (Round 1's 10/10 must
+  not regress under the leaner corpus).
+- Kill criterion (commitment 2), binary and mechanical:
+  `aria-required-parent`, `aria-required-children` and `listitem` appear in
+  **zero** `verify/*.jsonl` lines of D20.
+
+## Ruler v2 — what it must separate (spec direction, frozen separately)
+
+The v1 classifier reads *constancy of doing well*, *uniformity of doing
+little*, and *adaptation where context demands* as the same thing. v2
+separates them, and is built against the **dated fixtures Round 1 produced**,
+as an executable test suite frozen with the ruler:
+
+- **Fixture: adaptation punished.** All 10 D journeys pay +1 excess for the
+  `aria-sort` pair (`orders` announces sorting, `dashboard` doesn't sort) —
+  v2 must score justified divergence as 0.
+- **Fixture: uniformity by poverty.** `antigravity A run1–5` score excess 0
+  with zero live regions, zero dialogs, zero cards — v2 must not award a
+  perfect score to journeys that instantiate almost nothing.
+- **Fixture: the half-climbed ladder.** `antigravity__journey__D__run3` must
+  read as an *error*, not as dispersion.
+- **Defect to fix:** the `cards()` detector finds 0 instances in 27 of 30
+  Round 1 runs of a bookstore whose primary family is the book card — the
+  detector requires direct children and breaks on wrappers. v2's suite must
+  include a fixture from Round 1's real card grids.
+- v2 ships as `CLASSIFIER-v2.md` + `classifier-v2.py`, SHA-256 in the header,
+  fixtures in-repo and runnable (`--self-test`), frozen before registration.
+
+## Instrument discipline (Round 1's four defects, now protocol)
+
+- **Human-eye sampling rule (was a promise, now a rule):** no measurement
+  batch enters results before a seeded random sample of its artifacts passes
+  a human eye, logged in the run journal.
+- Dual reporting on any instrument correction (defective measurement
+  preserved side by side), per the house pattern.
+- `DEVIATIONS.md` starts empty; the frozen snapshot proves it; fill-ins
+  pre-declared here (registration URL, README status boxes) are not
+  deviations.
+
+## Diet accounting (context, not an outcome)
+
+`tools/context-cost.py --compare v1.8.0` is run at freeze time and its table
+enters the registration as descriptive context: core +1.5%; per-task delta
+range −2.1% to **+9.6%** (navigation); two new guides (~15.8 KB) and one
+merged away. The adherence question this table motivates is answered by the
+per-obligation panel, not by token arithmetic.
+
+## Cost plan (measured, Round 1)
+
+- Claude Code: median 26–33 min/run → 20 runs ≈ **9–10 h** wall clock.
+- Antigravity: ~1–2 min/run → 20 runs ≈ **40 min** (fresh OS profile + gate
+  probe per Round 1's discipline).
+- Tokens per D journey (fresh, median): 62k/screen large, 41k small — same
+  order as Round 1; $0 marginal under existing plans; quota walls are the
+  pace-setter, with the cut rule declared above.
+
+## Open questions (decided before freeze, by the author)
+
+1. **Codex as third agent?** Its quota resets 2026-09-16. Adding it makes the
+   round 60 runs and reopens the Round-1 gap; skipping keeps symmetry with
+   Round 1's realized arms. Default if undecided: skip, note the reset date.
+2. **Amortization curve (3/7/14-screen journeys)?** Roadmap item from the
+   report; tripling cost and requiring a re-calibrated clock for 14 screens.
+   Default: **out of scope** for Round 2 — it deserves its own protocol.
+3. **Registration timing:** freeze ruler v2 first, then register, then
+   collect — calendar to be set against CSUN's manuscript window (notification
+   due 2026-09-22).
+
+## Status
+
+- [ ] Ruler v2 spec + fixtures + `classifier-v2.py` (frozen by hash)
+- [ ] Pilot run (1 journey per agent, discarded by rule)
+- [ ] This protocol frozen (hash in header) after open questions close
+- [ ] OSF registration (own registration; cites pg6r5 §exploratory precedent)
+- [ ] Collection opens with the dated `DEVIATIONS.md` entry

--- a/benchmark/round2/PROTOCOL-DRAFT.md
+++ b/benchmark/round2/PROTOCOL-DRAFT.md
@@ -1,164 +1,253 @@
 # Round 2 — the v2.0.0 audit (v1.8.0 × v2.0.0)
 
-> **DRAFT — not frozen, not registered.** This document follows the order of
-> operations Study 2 established: pilot (discarded) → ruler v2 frozen by hash →
-> OSF registration (its own registration) → collection. Nothing here binds
-> until the freeze; everything after the freeze binds via `DEVIATIONS.md`.
+> **DRAFT v2 — not frozen, not registered.** Revised in full after an
+> independent methodological panel review (six lenses, adversarial
+> verification; parecer of 2026-08-29). Order of operations inherited from
+> Study 2: open questions closed by written rule → executable rulers frozen by
+> hash → pilot (discarded) → this protocol frozen → OSF registration (its own
+> registration) → collection. Nothing binds until the freeze; after it,
+> everything routes through `DEVIATIONS.md`.
 
 ## Why this round exists
 
 v2.0.0 was built from Study 2's findings and carries three public commitments
 ([CHANGELOG](../../CHANGELOG.md), the published report):
 
-1. **Non-regression of the diet.** The release cut ~56 KB across the corpus in
-   two declared bands while *adding* 9 obligations (62 → 71 per edition). The
-   honest arithmetic (measured by `git ls-tree` between tags): −35.7 KB shrunk
-   in pre-existing files, +10.2 KB grown, +15.8 KB in new guides, −4.5 KB
-   deleted — **net corpus −9.7 KB, core +605 B**. The hypothesis to refute is
-   therefore not "less context, worse output"; it is **"adherence to the old
-   obligations fell during the rewrite"**. The outcome is per-obligation, not
-   volume.
-2. **The kill criterion.** Study 2's one half-climbed ARIA ladder
-   (`antigravity__journey__D__run3`: `aria-required-parent` 49 nodes +
-   `listitem` 49 + `aria-required-children` 7, one mold replicated across all
-   7 screens) must **disappear as a class**, not be patched per case.
+1. **Non-regression of the diet.** The release cut ~56 KB gross across the
+   corpus in two declared bands while *adding* 9 obligations (62 → 71 per
+   edition). Measured between tags: −35.7 KB shrunk in pre-existing files,
+   +10.2 KB grown, +15.8 KB new guides, −4.5 KB deleted — **net corpus
+   −9.7 KB, core +605 B**. The refutable hypothesis is therefore
+   **"adherence to the old obligations fell during the rewrite"** — measured
+   per obligation, never as volume.
+2. **The kill criterion.** Study 2's half-climbed ARIA ladder (one mold
+   replicated across 7 screens) must disappear **as a class**, not as a case.
 3. **The contrast bet.** Contrast failed in every uninstructed condition of
-   Study 2 and survived in 3 of 5 guided journeys. v2.0.0 moved contrast from
-   model reasoning to a deterministic protocol (computed-never-estimated,
-   palette-definition trigger). This round measures whether the bet paid.
+   Study 2 and survived in 3 of 5 guided journeys — all three in the
+   Antigravity arm; the Claude Code D arm was already at zero. v2.0.0 moved
+   contrast to a deterministic protocol. This round measures whether the bet
+   paid, **per agent**, with floor rules declared below.
 
-Study 1's `METHODOLOGY.md` §exploratory declared "Version delta — same tasks
-against a prior release of the standard" as an exploratory outcome. **This
-round promotes that outcome to primary**, and the registration must say so,
-citing the precedent.
+**Lineage note (corrected):** Study 1's registration (osf.io/pg6r5) declared
+an exploratory *version delta* outcome — token cost on component tasks via
+API, a different unit, outcome and engine. That registration recorded the
+*question*; this round registers the version comparison as **its own primary
+study** on the journey unit. Motivation cited, not an outcome promoted.
 
 ## Design
 
 - **Unit:** the frozen `bookstore-journey` (7 screens, one session, one
   agent), prompt verbatim from [`../study2/PROMPTS.md`](../study2/PROMPTS.md).
-  Unchanged, for direct comparability with Round 1's 30 runs.
-- **Conditions (4):**
-  - **A** — bare (no instruction)
-  - **B** — generic (`Make it accessible.` prepended)
-  - **D18** — the standard at tag `v1.8.0`
-  - **D20** — the standard at tag `v2.0.0`
-  - No placebo, per Study 2's registered rationale (the placebo question is
-    answered; a journey costs hours). The slug keeps Study 2's 4-field shape
-    (`agent__journey__COND__runN`) so `run.py --resume`, `log.jsonl` and
-    `analyze.py` survive with label changes only.
-- **Workspace freezing:** condition workspaces are built from
-  `git archive <tag> -- docs/en`, never from the working tree. The
-  registration records, per condition, the SHA-256 of the archive's files
-  **concatenated in path order** — the same idiom Study 1 used for
-  `control-standard/`.
-- **Agents (2):** Claude Code and Antigravity, versions named at registration
-  (Round 1's clients no longer exist at those versions; Round 1 data is
-  context, never a pooled arm). Codex quota resets 2026-09-16; whether it
-  enters as a third agent is an **open question** below.
-- **n:** 5 per cell → `5 × 4 × 2 = 40 runs`. Cut rule inherited: if 40 proves
-  infeasible, agents are cut before repetitions.
-- **Clock:** 90 min per run, symmetric, inherited from Study 2's calibration.
-- **Blinding:** screen HTML renamed by hash with a sealed map before any human
-  look; governance artifacts counted by script, never read before adjudication.
+  Unchanged for comparability of unit — Round 1 data is context, never a
+  pooled arm (its client versions no longer exist).
+- **Conditions (4):** A (bare) · B (`Make it accessible.` prepended) ·
+  **D18** (the standard at tag `v1.8.0`) · **D20** (at tag `v2.0.0`). No
+  placebo, per Study 2's registered rationale. Slugs keep the 4-field shape:
+  `agent__journey__{A|B|D18|D20}__runN`.
+- **Treatment definition (closed path list).** Each D workspace is built from
+  `git archive <tag> -- docs/en/A11Y.md docs/en/references docs/en/templates
+  tools` — the Round-1 workspace list **plus the release's own `tools/`
+  directory, from the same tag**. Rationale, registered here: the
+  deterministic contrast checker is part of what v2.0.0 *is* (its core orders
+  ratios computed, tool or formula); testing the release without its tool
+  would test a hypothetical, not the shipped standard. The asymmetry
+  (`tools/` at v1.8.0 has no `contrast-check.py`) **is the treatment** —
+  release-as-delivered, both sides. Per-condition SHA-256 over the archive's
+  files concatenated in path order enters the registration.
+- **Shell affordance is measured, not assumed.** The runner invokes Claude
+  Code with the same permission mode as Round 1 (unchanged, for harness
+  comparability) — a mode that does not auto-approve Bash. The pilot
+  therefore runs **one D20 journey per agent** and records the observed
+  affordance (shell granted? tool executed? formula path taken?) in the
+  journal before the freeze. If an agent cannot run the tool, the protocol
+  declares: for that agent, D20 measures the formula path by construction —
+  the fallback the standard itself prescribes.
+- **Agents (2):** Claude Code and Antigravity, client versions named at
+  registration. **Codex rule (closed):** Codex enters only if its quota is
+  active and the client installable on freeze day; its quota resets
+  2026-09-16, colliding with the calendar below — default executed: **skip**,
+  Codex named a Round-3 candidate.
+- **n:** 5 per cell → `5 × 4 × 2 = 40 runs`. Cut rule inherited: agents are
+  cut before repetitions.
+- **Collection order:** interleaved by run index — for each index 1..5, run
+  A, B, D18, D20 (in that order) before the next index, including under
+  `--resume`. Client auto-update disabled where the product allows; the
+  client version is logged per run and the runner **aborts** if it differs
+  from the registered one. Version changes are permitted only between
+  complete cycles, logged, and reported as a version×condition table.
+- **Retention and retry (mechanical):** a run is retained iff it produces 7
+  non-empty screens within the 90-minute clock (symmetric, inherited).
+  Retry only on infrastructure error (client crash, quota wall, network
+  failure — the verbatim error message is logged), maximum 2 retries,
+  nothing deleted; per-cell failure rates are reported as data.
+- **Clock:** 90 min per run, symmetric (Round-1 calibration, >2× headroom).
 
-## Outcomes and the declared hierarchy (the ruler-v2 commitment)
+## Environment hygiene (the Round-1 lesson, now protocol)
 
-Study 2 published five rulers but ranked them post-hoc. Round 2 declares the
-hierarchy **before** collection, with the judge named per ruler:
+Round 1's Claude Code arm inherited the operator's live environment; the
+generic condition hunted for the standard (see
+[`../study2/DEVIATIONS.md`](../study2/DEVIATIONS.md), entry 2026-08-29 —
+leakage direction conservative, but undeclared). Round 2:
 
-| # | Ruler | Serves | Judge | Status in code |
-| - | ----- | ------ | ----- | -------------- |
-| 1 | **Screens with error** (screen×error pairs) | the person navigating | axe (frozen) + script | to be frozen (was post-hoc) |
-| 2 | **Wrong decisions** (distinct error decisions) | the maintainer fixing | script over `verify/*.jsonl` | to be frozen (was hand-derived) |
-| 3 | **Clean journeys** (whole sites, zero violations) | the team shipping | script | to be frozen (was post-hoc) |
-| 4 | **Consistency v2** (see below) | the person relearning each screen | `classifier-v2.py` (frozen by hash) | to be built |
-| 5 | **Flagged elements** (raw node count) | the auditor | axe | frozen since Round 1 |
+- **Dedicated sanitized HOME per agent** — credentials and client
+  configuration only; no user skills, no personal `CLAUDE.md`, no vault
+  grants, no `additionalDirectories`. The profile's full contents are listed
+  in the frozen snapshot.
+- **Gate probe tests the symptom, per agent, before any retained run:** a
+  B-style probe journey screen; retained only if the transcript contains no
+  reference to, or search for, the standard or the operator's files.
+- **Network policy:** web/search tools disabled where the client supports it;
+  the setting's state is registered per agent. Per-run audit: for Claude
+  Code, `server_tool_use` and `permission_denials` from the native capture
+  (must show zero web access); for Antigravity, a transcript grep — declared
+  as a **limit**, not sold as a guarantee. A contaminated run is excluded and
+  recollected, with a dated `DEVIATIONS.md` entry. Training-data cutoff
+  defense stated in the registration; the core's upstream-repo line is
+  byte-identical in both tags and is a *declaration*, never edited in the
+  corpus (editing would break the tag hash and the ecological premise).
 
-Primary contrast: **D20 vs D18** on rulers 1–4. Secondary: D20 vs B, D20 vs A.
-Statistics inherited: seeded bootstrap (B=10,000), Cliff's delta, no p-values,
-never pooled across agents.
+## Outcomes, rulers and the decision panel
 
-### Per-obligation non-regression panel (commitment 1)
+**Statistical posture, verbatim from the registered Round 1: this study is
+descriptive and estimation-oriented — not confirmatory at this n.** The
+commitments below are falsifiable checks, not hypotheses this n can confirm.
+Primary contrast: **D20 vs D18, same-agent, never pooled.** Secondary: D20 vs
+B, D20 vs A. Seeded bootstrap (B=10,000), Cliff's delta, no p-values. Where a
+screen-grain outcome is used, the bootstrap **resamples by journey cluster**
+(screens within a session are correlated). Printed in the registration so no
+reader over-reads: the null SD of Cliff's delta at n=5×5 is ≈0.38 — only
+near-complete separation is distinguishable from noise.
 
-The floor is what Round 1 already banked, checked per class, per condition:
+### The five rulers — declared hierarchy, named judges, all executable
 
-- `image-alt` and `label` classes: **zero across all D20 journeys** (Round 1
-  zeroed them in D; they must stay zero).
-- `color-contrast`: Round 1 had it in 3 of 5 D journeys — under the v2.0.0
-  deterministic protocol the target is **fewer affected journeys than D18**,
-  measured same-agent.
-- Governance pair (REPORT + DECISIONS): **10/10 in D20** (Round 1's 10/10 must
-  not regress under the leaner corpus).
-- Kill criterion (commitment 2), binary and mechanical:
-  `aria-required-parent`, `aria-required-children` and `listitem` appear in
-  **zero** `verify/*.jsonl` lines of D20.
+| # | Ruler | Serves | Judge (frozen) |
+| - | ----- | ------ | -------------- |
+| 1 | **Screens with error** — screen×error pairs, axe critical+serious. *Construct qualified: the machine-detectable layer only (axe-class coverage 30–57% in the literature, cited in the registration).* | the person navigating | `rulers.py screens` |
+| 2 | **Wrong decisions** — distinct violated rules per journey (each error counted once however often its mold repeats). Definition frozen in `RULERS.md`, validated in `--self-test` against Round 1's published 9/11/8. | the maintainer fixing | `rulers.py decisions` |
+| 3 | **Clean journeys** — descriptive only, base rates printed (Round 1: 0/5 · 0/5 · 2/5 on the small model). | the team shipping | `rulers.py clean` |
+| 4 | **Consistency v2** — see spec direction below; frozen as `classifier-v2.py`. The frozen v1 (hash intact) runs over all Round-2 data as a **sensitivity analysis**; both results published; divergence reported as a finding about the instrument. | the person relearning each screen | `classifier-v2.py` |
+| 5 | **Flagged elements** — raw node count (registered since Round 1). | the auditor | axe + `analyze.py` |
 
-## Ruler v2 — what it must separate (spec direction, frozen separately)
+All rulers 1–3 ship as **frozen scripts with `--self-test`** whose fixtures
+are Round-1 data — including, per ruler, at least one fixture where the
+standard's condition *loses* (they exist: Antigravity D lost ruler 1, 38 vs
+13). Freezing them is a gate in the Status checklist, same discipline as
+ruler 4.
 
-The v1 classifier reads *constancy of doing well*, *uniformity of doing
-little*, and *adaptation where context demands* as the same thing. v2
-separates them, and is built against the **dated fixtures Round 1 produced**,
-as an executable test suite frozen with the ruler:
+### The per-obligation non-regression panel (canonical mapping)
 
-- **Fixture: adaptation punished.** All 10 D journeys pay +1 excess for the
-  `aria-sort` pair (`orders` announces sorting, `dashboard` doesn't sort) —
-  v2 must score justified divergence as 0.
-- **Fixture: uniformity by poverty.** `antigravity A run1–5` score excess 0
-  with zero live regions, zero dialogs, zero cards — v2 must not award a
-  perfect score to journeys that instantiate almost nothing.
-- **Fixture: the half-climbed ladder.** `antigravity__journey__D__run3` must
-  read as an *error*, not as dispersion.
-- **Defect to fix:** the `cards()` detector finds 0 instances in 27 of 30
-  Round 1 runs of a bookstore whose primary family is the book card — the
-  detector requires direct children and breaks on wrappers. v2's suite must
-  include a fixture from Round 1's real card grids.
-- v2 ships as `CLASSIFIER-v2.md` + `classifier-v2.py`, SHA-256 in the header,
-  fixtures in-repo and runnable (`--self-test`), frozen before registration.
+This panel is the **single canonical mapping** commitment→estimand→criterion.
+Binary language is reserved for the kill criterion alone; everything else is
+an estimand with edge cases closed:
 
-## Instrument discipline (Round 1's four defects, now protocol)
+| Check | Rule | Edge cases (closed) |
+| ----- | ---- | ------------------- |
+| `image-alt`, `label` classes | Floor: zero across D20 journeys (Round 1 banked zero in D) | **One** isolated violation → topology inspection (mold vs lapse), reported, not auto-veto; **≥2 journeys affected** → regression, stated as such |
+| Any other axe class at zero in D18 (same agent) | Generalized floor: reappearance in ≥2 D20 journeys = regression | Same isolated-violation rule |
+| `color-contrast` (the bet) | Per agent: **corroborated** iff (D18>0 and D20<D18) **or** (D18=0 and D20=0); **refuted** iff D20>D18; tie at >0 = not corroborated | Antigravity named as the only informative arm from Round 1 (Claude Code D was 0/5 — floor rule applies: staying at zero = success). Directional reading with the estimand's CI beside it, never a lone verdict |
+| Governance pair (REPORT + DECISIONS) | Proportion with CI (Round 1: 10/10 vs 0/20); pre-declared reading of a single miss: inspect the journal before "regression" | 10/10 expected; 9/10 is inspected, not headlined |
+| Kill criterion | **Binary.** The ladder **class list**, derived from axe 4.13.0's ARIA structural rules and published with its derivation: `aria-required-parent`, `aria-required-children`, `listitem`, `dlitem`, `definition-list`, `aria-required-attr`. Zero appearances in all D20 `verify/*.jsonl` **and** the 2×2 table against D18 fresh (if D18 also zeroes, the zero evidences the client era, not §6 — stated). Base rate printed: 1/10 Round-1 D journeys; P(zero in 10 | no change) = 0.9¹⁰ ≈ 0.35 | The comparator column is what makes the zero interpretable |
+
+**Two-agent adjudication rule (pre-declared):** commitments are judged
+same-agent; when the two agents diverge, both verdicts are reported and the
+**less favorable one leads the write-up**. No synthesis averages them.
+
+### What will and will not be claimed
+
+- **Publication is unconditional on outcome** — the Round-1 precedent
+  ("published however it comes out") is the operating rule.
+- Claims about commitments come **only** from the canonical panel above. All
+  other cells are descriptive, labeled so, and barred from headlines.
+- Ruler-1 improvements are claims about the machine-detectable layer, never
+  about the full navigation experience.
+- **Consequence table (pre-written):**
+  - Kill criterion fails → §6's ladder rule is reopened as a *structural
+    defect* of v2.0.0, fixed in a v2.0.x release, CHANGELOG amended, and the
+    failure headlined in the round's report.
+  - Contrast bet refuted (either agent) → "the bet paid" is unpublishable;
+    a dated note corrects the v2.0.0 announcement narrative.
+  - Any floor regression → named in the report's lead, with the topology
+    inspection attached; the diet's band-B cuts are re-examined first.
+  - Mixed results across agents → the less favorable verdict leads (rule
+    above); "it depends on the agent" is a finding, not a hedge.
+
+## Ruler v2 — spec direction (frozen separately as `CLASSIFIER-v2.md`)
+
+v1 reads *constancy of doing well*, *uniformity of doing little* and
+*adaptation where context demands* as the same thing. v2 separates them under
+these constraints, panel-reviewed:
+
+- Every rule derived from a Round-1 fixture enters as a **condition-blind
+  general principle** (e.g., the state dimension compares only instances with
+  the same functional capability — no whitelists), with **held-out synthetic
+  counter-fixtures** in `--self-test` proving the same pattern scores
+  identically wherever it appears.
+- **Dispersion stays a pure metric; poverty becomes a separate denominator**
+  (variant excess reported beside instantiated-family counts, never fused
+  into one score).
+- Ruler 4 measures **consistency over valid instances**, with the validity
+  check itself frozen and exclusion counts reported per condition.
+- Known v1 defects to fix, with fixtures: the `aria-sort` adaptation pair
+  (10/10 D journeys penalized for doing right — present in 25/30 journeys
+  overall, condition-neutral), uniformity-by-poverty (Antigravity A: perfect
+  scores instantiating almost nothing), the half-climbed ladder read as
+  dispersion, and the card detector blind in 27/30 runs of a bookstore.
+- The frozen **v1 runs over all Round-2 data as sensitivity analysis** (cost:
+  seconds; gain: cross-round auditability).
+
+## Instrument discipline
 
 - **Human-eye sampling rule (was a promise, now a rule):** no measurement
   batch enters results before a seeded random sample of its artifacts passes
   a human eye, logged in the run journal.
-- Dual reporting on any instrument correction (defective measurement
-  preserved side by side), per the house pattern.
-- `DEVIATIONS.md` starts empty; the frozen snapshot proves it; fill-ins
-  pre-declared here (registration URL, README status boxes) are not
-  deviations.
+- Dual reporting on any instrument correction; defective measurements
+  preserved side by side.
+- **Blinding, scoped in three sentences:** script-computed outcomes need no
+  blinding and claim none. Human QA looks only at hash-renamed screens
+  (sealed map); any correction it triggers applies to the entire corpus.
+  Governance artifacts self-reveal their version by content — they reach
+  human eyes only after all outcomes are computed; residual limit declared.
+- `DEVIATIONS.md` starts empty (frozen snapshot proves it); pre-declared
+  fill-ins (registration URL, README status boxes) are not deviations.
 
 ## Diet accounting (context, not an outcome)
 
-`tools/context-cost.py --compare v1.8.0` is run at freeze time and its table
-enters the registration as descriptive context: core +1.5%; per-task delta
-range −2.1% to **+9.6%** (navigation); two new guides (~15.8 KB) and one
-merged away. The adherence question this table motivates is answered by the
-per-obligation panel, not by token arithmetic.
+`tools/context-cost.py --compare v1.8.0` is run at freeze time; its table
+enters the registration as descriptive context (core +1.5%; per-task delta
+−2.1% to **+9.6%**, navigation; two new guides; one merged away). The
+adherence question is answered by the panel, not by token arithmetic.
 
 ## Cost plan (measured, Round 1)
 
-- Claude Code: median 26–33 min/run → 20 runs ≈ **9–10 h** wall clock.
-- Antigravity: ~1–2 min/run → 20 runs ≈ **40 min** (fresh OS profile + gate
-  probe per Round 1's discipline).
-- Tokens per D journey (fresh, median): 62k/screen large, 41k small — same
-  order as Round 1; $0 marginal under existing plans; quota walls are the
-  pace-setter, with the cut rule declared above.
+Claude Code median 26–33 min/run → 20 runs ≈ 9–10 h wall clock; Antigravity
+1–2 min/run under fresh-profile discipline → ≈ 40 min + probes. $0 marginal;
+quota walls set the pace, cut rule declared.
 
-## Open questions (decided before freeze, by the author)
+## Closed questions (were open; now rules)
 
-1. **Codex as third agent?** Its quota resets 2026-09-16. Adding it makes the
-   round 60 runs and reopens the Round-1 gap; skipping keeps symmetry with
-   Round 1's realized arms. Default if undecided: skip, note the reset date.
-2. **Amortization curve (3/7/14-screen journeys)?** Roadmap item from the
-   report; tripling cost and requiring a re-calibrated clock for 14 screens.
-   Default: **out of scope** for Round 2 — it deserves its own protocol.
-3. **Registration timing:** freeze ruler v2 first, then register, then
-   collect — calendar to be set against CSUN's manuscript window (notification
-   due 2026-09-22).
+1. **Codex:** skip (rule and reset date above); Round-3 candidate.
+2. **Amortization curve (3/7/14 screens):** out of scope; own protocol.
+3. **Calendar:** counted backwards from CSUN notification (2026-09-22). If
+   the checklist below does not fit **with slack**, the freeze is not
+   compressed to fit — the CSUN manuscript cites the registered Round-1
+   material; a rushed freeze is the door post-hoc walks through.
 
-## Status
+## Status — every box gates the freeze
 
-- [ ] Ruler v2 spec + fixtures + `classifier-v2.py` (frozen by hash)
-- [ ] Pilot run (1 journey per agent, discarded by rule)
-- [ ] This protocol frozen (hash in header) after open questions close
-- [ ] OSF registration (own registration; cites pg6r5 §exploratory precedent)
+- [ ] Rulers 1–3: `RULERS.md` definitions + `rulers.py` frozen by hash,
+      `--self-test` reproducing Round 1's published numbers (33/13/38 ·
+      9/11/8 · 0-0-2/5) and containing a D-loses fixture per ruler
+- [ ] Ruler v2: `CLASSIFIER-v2.md` + `classifier-v2.py` frozen by hash,
+      condition-blind principles + held-out counter-fixtures in `--self-test`
+- [ ] Kill-criterion class list derivation published (axe 4.13.0 structural
+      rules; native and keyboard boundaries resolved)
+- [ ] `round2/run.py` + `round2/analyze.py`: 4 conditions, tag-archived
+      workspaces, D20−D18 implemented, interleaving, version pinning,
+      mechanical retry; frozen by hash; validated against a synthetic 40-run
+      fixture
+- [ ] Sanitized per-agent HOME built; contents listed; gate probes defined
+- [ ] Pilot: 1 journey per agent (discarded), D20 affordance probe (shell /
+      tool / formula path) + gate probes; observations journaled
+- [ ] This protocol frozen (hash in header)
+- [ ] OSF registration (own registration; lineage note as written above)
 - [ ] Collection opens with the dated `DEVIATIONS.md` entry

--- a/benchmark/round2/rulers.py
+++ b/benchmark/round2/rulers.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""
+rulers.py — Round 2's executable rulers 1, 2, 3 and 5, plus the kill-criterion
+checker and the per-obligation floor panel.
+
+Round 1 published five rulers but three existed only as prose (post-hoc
+readings, hand-derived). Round 2's protocol requires every ruler to be frozen
+executable code BEFORE registration, self-tested against Round 1's published
+numbers — so the definitions cannot drift after the data arrives.
+
+Input: a directory of verify JSONL files (one per run; 7 lines, one per
+screen; each line: {"id", "violations": [{"id", "impact", "nodes"}, ...]}).
+Run ids follow `agent__journey__COND__runN`.
+
+Rulers (impact filter: critical + serious, axe 4.13.0 — frozen):
+  screens    ruler 1 — screen×error pairs (each distinct violated rule counted
+             once per screen it appears on)
+  decisions  ruler 2 — distinct violated rules PER JOURNEY, summed over the
+             condition (each journey is an independent project: the same
+             wrong rule in two journeys is two decisions; within a journey it
+             is one, however many screens repeat its mold). Definition fixed
+             by reproducing Round 1's published 9/11/8 — see --self-test.
+  clean      ruler 3 — journeys with zero critical+serious violations
+  elements   ruler 5 — total flagged nodes
+  kill       the ladder-class checker: structural ARIA parent/child rules
+  floors     per-obligation panel: image-alt, label, color-contrast per journey
+
+  --self-test  validates every ruler against Round 1's published Table-5
+               numbers from runs/study2/verify. A ruler that cannot reproduce
+               the published reading is a defect HERE, found before the freeze.
+
+Stdlib only, no dependencies. This tool does not establish conformance; it
+counts what axe already measured.
+"""
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+IMPACTS = ("critical", "serious")
+
+# The ladder class, derived from axe 4.13.0's ARIA/structural parent-child
+# rules (derivation published in PROTOCOL-DRAFT.md): a composite pattern
+# announced but not completed. Frozen list.
+KILL_CLASS = (
+    "aria-required-parent",
+    "aria-required-children",
+    "listitem",
+    "dlitem",
+    "definition-list",
+    "aria-required-attr",
+)
+
+# The floor panel's obligation classes (axe rule ids).
+FLOOR_CLASSES = {
+    "image-alt": ("image-alt", "input-image-alt", "role-img-alt", "svg-img-alt", "area-alt"),
+    "label": ("label", "select-name", "form-field-multiple-labels", "aria-input-field-name"),
+    "color-contrast": ("color-contrast",),
+}
+
+
+def parse_run(path: Path):
+    screens = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if line.strip():
+            screens.append(json.loads(line))
+    return screens
+
+
+def load(verify_dir: Path):
+    """{(agent, cond, runN): [screen dicts]}"""
+    runs = {}
+    for f in sorted(verify_dir.glob("*.jsonl")):
+        parts = f.stem.split("__")
+        if len(parts) != 4:
+            continue
+        agent, _journey, cond, run = parts
+        runs[(agent, cond, run)] = parse_run(f)
+    if not runs:
+        sys.exit(f"ERROR: no agent__journey__cond__runN.jsonl files in {verify_dir}")
+    return runs
+
+
+def serious_violations(screen):
+    return [v for v in screen.get("violations", []) if v.get("impact") in IMPACTS]
+
+
+def ruler_screens(runs):
+    """Ruler 1: screen×error pairs per (agent, cond)."""
+    out = defaultdict(int)
+    for (agent, cond, _run), screens in runs.items():
+        out[(agent, cond)] += 0  # register the cell even at zero
+        for s in screens:
+            out[(agent, cond)] += len(serious_violations(s))
+    return dict(out)
+
+
+def ruler_decisions(runs):
+    """Ruler 2: distinct violated rules per journey, summed per (agent, cond)."""
+    out = defaultdict(int)
+    for (agent, cond, _run), screens in runs.items():
+        out[(agent, cond)] += 0  # register the cell even at zero
+        per_journey = {v["id"] for s in screens for v in serious_violations(s)}
+        out[(agent, cond)] += len(per_journey)
+    return dict(out)
+
+
+def ruler_clean(runs):
+    """Ruler 3: journeys with zero critical+serious, per (agent, cond)."""
+    total = defaultdict(int)
+    clean = defaultdict(int)
+    for (agent, cond, _run), screens in runs.items():
+        total[(agent, cond)] += 1
+        if not any(serious_violations(s) for s in screens):
+            clean[(agent, cond)] += 1
+    return {k: (clean[k], total[k]) for k in total}
+
+
+def ruler_elements(runs):
+    """Ruler 5: total flagged nodes (critical+serious), per (agent, cond)."""
+    out = defaultdict(int)
+    for (agent, cond, _run), screens in runs.items():
+        out[(agent, cond)] += 0  # register the cell even at zero
+        for s in screens:
+            for v in serious_violations(s):
+                out[(agent, cond)] += v.get("nodes", 0)
+    return dict(out)
+
+
+def kill_table(runs):
+    """Ladder-class appearances: per (agent, cond) → journeys affected, nodes."""
+    out = {}
+    for (agent, cond, run), screens in runs.items():
+        nodes = sum(
+            v.get("nodes", 0)
+            for s in screens
+            for v in s.get("violations", [])
+            if v["id"] in KILL_CLASS
+        )
+        key = (agent, cond)
+        j, n = out.get(key, (0, 0))
+        out[key] = (j + (1 if nodes else 0), n + nodes)
+    return out
+
+
+def floors(runs):
+    """Per-obligation panel: journeys affected per class, per (agent, cond)."""
+    out = defaultdict(lambda: defaultdict(int))
+    for (agent, cond, _run), screens in runs.items():
+        hit = set()
+        for s in screens:
+            for v in s.get("violations", []):
+                for cls, ids in FLOOR_CLASSES.items():
+                    if v["id"] in ids and v.get("nodes", 0) > 0:
+                        hit.add(cls)
+        for cls in hit:
+            out[(agent, cond)][cls] += 1
+    return {k: dict(v) for k, v in out.items()}
+
+
+def report(verify_dir: Path):
+    runs = load(verify_dir)
+    blocks = {
+        "ruler1_screen_error_pairs": {f"{a}/{c}": v for (a, c), v in sorted(ruler_screens(runs).items())},
+        "ruler2_distinct_decisions": {f"{a}/{c}": v for (a, c), v in sorted(ruler_decisions(runs).items())},
+        "ruler3_clean_journeys": {f"{a}/{c}": f"{x}/{t}" for (a, c), (x, t) in sorted(ruler_clean(runs).items())},
+        "ruler5_flagged_nodes": {f"{a}/{c}": v for (a, c), v in sorted(ruler_elements(runs).items())},
+        "kill_class": {f"{a}/{c}": {"journeys": j, "nodes": n} for (a, c), (j, n) in sorted(kill_table(runs).items())},
+        "floor_panel_journeys_affected": {f"{a}/{c}": v for (a, c), v in sorted(floors(runs).items())},
+    }
+    print(json.dumps(blocks, indent=1))
+
+
+def self_test():
+    """Reproduce Round 1's published readings from runs/study2/verify."""
+    verify = Path(__file__).resolve().parent.parent / "runs" / "study2" / "verify"
+    if not verify.is_dir():
+        sys.exit(f"self-test needs Round 1 data at {verify} (published on Zenodo)")
+    runs = load(verify)
+    ok = True
+
+    def check(name, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {name}: got {got} want {want} {'ok' if good else 'SELF-TEST FAILURE'}")
+
+    r1, r2 = ruler_screens(runs), ruler_decisions(runs)
+    r3, r5 = ruler_clean(runs), ruler_elements(runs)
+    kt, fl = kill_table(runs), floors(runs)
+
+    print("ruler 1 — published: antigravity A/B/D = 33/13/38 (screen×error pairs)")
+    for cond, want in (("A", 33), ("B", 13), ("D", 38)):
+        check(f"antigravity {cond}", r1.get(("antigravity", cond)), want)
+
+    print("ruler 2 — published: antigravity A/B/D = 9/11/8 (distinct wrong decisions)")
+    for cond, want in (("A", 9), ("B", 11), ("D", 8)):
+        check(f"antigravity {cond}", r2.get(("antigravity", cond)), want)
+
+    print("ruler 3 — published: antigravity A/B/D = 0/5, 0/5, 2/5 clean journeys")
+    for cond, want in (("A", (0, 5)), ("B", (0, 5)), ("D", (2, 5))):
+        check(f"antigravity {cond}", r3.get(("antigravity", cond)), want)
+
+    print("ruler 5 — published: antigravity A/B/D = 167/42/144 flagged nodes; claude-code = 369/0/0")
+    for agent, cond, want in (
+        ("antigravity", "A", 167), ("antigravity", "B", 42), ("antigravity", "D", 144),
+        ("claude-code", "A", 369), ("claude-code", "B", 0), ("claude-code", "D", 0),
+    ):
+        check(f"{agent} {cond}", r5.get((agent, cond)), want)
+
+    print("kill class — published: exactly one D journey carries the ladder (98 structural nodes + the 7-screen children rule)")
+    check("antigravity D journeys", kt.get(("antigravity", "D"), (0, 0))[0], 1)
+    check("claude-code D journeys", kt.get(("claude-code", "D"), (0, 0))[0], 0)
+
+    print("floor panel — published: contrast in 3/5 antigravity D journeys, 0/5 claude-code D; image-alt and label at zero in all D")
+    check("antigravity D color-contrast", fl.get(("antigravity", "D"), {}).get("color-contrast", 0), 3)
+    check("claude-code D color-contrast", fl.get(("claude-code", "D"), {}).get("color-contrast", 0), 0)
+    check("antigravity D image-alt", fl.get(("antigravity", "D"), {}).get("image-alt", 0), 0)
+    check("claude-code D image-alt", fl.get(("claude-code", "D"), {}).get("image-alt", 0), 0)
+    check("antigravity D label", fl.get(("antigravity", "D"), {}).get("label", 0), 0)
+    check("claude-code D label", fl.get(("claude-code", "D"), {}).get("label", 0), 0)
+
+    print("D-loses fixtures (the rulers must be able to score against the standard):")
+    check("ruler 1: antigravity D (38) worse than B (13)", r1.get(("antigravity", "D"), 0) > r1.get(("antigravity", "B"), 0), True)
+    check("ruler 5: antigravity D (144) worse than B (42)", r5.get(("antigravity", "D"), 0) > r5.get(("antigravity", "B"), 0), True)
+
+    print("self-test:", "PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("verify_dir", nargs="?", help="directory of verify *.jsonl files")
+    ap.add_argument("--self-test", action="store_true", help="validate against Round 1's published numbers")
+    args = ap.parse_args()
+    if args.self_test:
+        self_test()
+    if not args.verify_dir:
+        ap.print_help()
+        sys.exit(0)
+    report(Path(args.verify_dir))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this is

The Round 2 protocol draft, following the house rite (pilot → freeze → register → collect — nothing binds until the freeze). Built on a full reconnaissance of `benchmark/`, which surfaced three things the draft absorbs:

1. **The honest diet arithmetic.** The "~56 KB cut" is the sum of what was removed; the *net* corpus fell only 9.7 KB and the core grew 605 B, because the diet's budget bought new guides and 9 new obligations. So the non-regression outcome is **adherence per obligation** (image-alt/label stay zero, contrast beats D18, governance 10/10 holds), never token volume.
2. **Three of the five published rulers exist only as prose.** Wrong-decisions, clean-journeys and screens-with-error were post-hoc in Round 1; here they are declared, judged and frozen as code *before* collection, with the hierarchy ranked (the person navigating first).
3. **Ruler v1's card detector is blind**: 0 card instances in 27 of 30 runs of a *bookstore*. Ruler v2's executable fixture suite includes this, plus the three dated cases the report promised: the `aria-sort` adaptation punished in all 10 D journeys, the uniformity-by-poverty A runs, and the 98-element half-climbed ladder (now a binary kill criterion: `aria-required-parent`/`aria-required-children`/`listitem` = zero in D20).

## Design in one line

Frozen bookstore journey, 4 conditions (A · B · **D18** · **D20** via `git archive` + path-order hashes), 2 agents, n=5 → 40 runs, ~9–10 h Claude Code + ~40 min Antigravity, 90-min symmetric clock, seeded bootstrap and Cliff's delta, no p-values.

## The three open questions (yours, before freeze)

1. **Codex as third agent?** Quota resets Sep 16. Default: skip, keep symmetry with Round 1.
2. **Amortization curve (3/7/14 screens)?** Default: out of scope — own protocol later.
3. **Calendar**: freeze + register against the CSUN window (notification Sep 22).

Next steps after your review: build `classifier-v2.py` + fixtures, pilot, freeze, register.

🤖 Generated with [Claude Code](https://claude.com/claude-code)