### PR TITLE
Round 2 instruments: classifier v2 (adversarially verified twice), runner, analysis, rulers doc, sanitized-home builder

### DIFF
--- a/benchmark/round2/CLASSIFIER-v2.md
+++ b/benchmark/round2/CLASSIFIER-v2.md
@@ -1,0 +1,306 @@
+# Consistency classifier v2 — specification
+
+> Status: **draft, adversarially verified twice — frozen when the hash is
+> recorded here at protocol freeze.** Code: `classifier_v2.py`
+> (stdlib-only, deterministic, condition-blind). v1
+> (`../study2/classifier.py`, sha256 `485d4064…`) stays untouched and
+> re-runnable as a sensitivity analysis.
+
+## Why a v2
+
+Round 2's protocol requires every ruler to exist as frozen executable code
+before registration. The instrument went through two hardening stages, both
+before any Round-2 data exists:
+
+1. **Calibration** — four independent agents each audited one suspected v1
+   defect against Round 1's 30 published journeys. All four confirmed
+   (cases A–D below); every fix was validated against the real corpus
+   before the first draft of this spec.
+2. **Adversarial verification, round 1** — an independent panel (three
+   lenses: gaming with constructed inputs, condition bias,
+   correctness/regressions) attacked the v2 draft; each finding was then
+   re-verified by a skeptic agent instructed to refute it. **16 findings
+   survived verification** and are fixed or documented below; **27 attacks
+   failed** (the panel's clean-areas list includes: mechanical
+   condition-blindness on real runs under swapped names, no proxy leaks,
+   anti-circularity of the table claim term, determinism across hash seeds
+   and `-O`, richness arithmetic, exclusion accounting, and independent
+   reproduction of the sensitivity table).
+3. **Adversarial verification, round 2** — a second panel attacked the
+   AMENDED instrument (the 16 fixes themselves) and hunted regressions the
+   fixes could have introduced. **13 findings survived skeptic
+   verification** (ledger below), **26 attacks failed**. Two had measured
+   real-corpus impact: a JS regex literal containing a quote corrupted the
+   literal-blanking pass and misread 4/30 runs (claude-code B run3's
+   excess read 0 instead of 1 — understating a NON-treatment cell), and a
+   nested live-region wrapper idiom in one antigravity D run was charged
+   +1 for one physical widget. Both directions, both fixed.
+
+### The four calibration cases (v1 defects)
+
+| # | Defect (v1) | Fix (v2) |
+|---|---|---|
+| A | `aria-sort` treated as a *variant*: a static table diverged from a sortable one that correctly declares `aria-sort` — punishing the better run. All 10 D journeys carried +1 excess for honest markup. | **Capability gate.** Structure `(container, heads)` is compared across all tables; sort *signalling* is compared only among sortable tables. Claiming `aria-sort` can only ADD a table to the pool (anti-circularity). |
+| B | Cards required a literal `<img>` in the static DOM. 25/30 real runs render the catalog client-side; 2 more use CSS-styled `div` covers. v1 saw cards in 3/30 runs. | **Two lanes.** DOM lane accepts `css-cover`; JS lane statically parses local script factories with receiver binding. Validated: 30/30 real runs detected. |
+| C | Structurally broken instances counted as *variants*: one run's menu ladder (`ul[role=menu] > li` without role) read as a second nav convention. | **Validity gate.** Required-parent/children composition checked per instance; invalid instances are excluded and *counted as exclusions*. Validated: exactly the 7 main-nav instances of one run excluded, zero elsewhere in 45 runs. |
+| D | `variant_excess = 0` was unreadable: zero-because-uniform and zero-because-poor looked identical. | **Richness block**, sibling of the excess, never fused. Protocol rule: **excess is only quotable together with `families_counted`.** |
+
+### The adversarial panel's amendments (v2-draft defects, all pre-freeze)
+
+Confirmed and **fixed**:
+
+| Lens | Finding | Fix |
+|---|---|---|
+| gaming | Validity gate blessed broken composites built from `div`+`a`/`button` (only `li`-style ladders errored) | `IMPLICIT` extended: interactive/semantic elements carry their real implicit roles (`a[href]`→link, `button`→button, `select`→listbox, `summary`→button, `input`→textbox/radio/checkbox, `table`, `nav`, `img` (with `alt=""`→presentation), headings, `hr`→separator). Only genuinely role-less tags stay generic/transparent. A composite with element content but zero owned items anywhere is invalid ("announced composite with zero items"). |
+| gaming | Richness gameable with contentless stubs (`<table></table>`, empty `<dialog>`, 6/6 families from shells) | **Substance predicates** per family; stubs go to `stub_instances` / `stub_detail`, outside variants, `families_counted` and coverage. Headers count as substance (a thead-only table populated client-side is legitimate static credit — the Round-1 antigravity D orders tables); empty live-region placeholders remain the correct idiom and are never stubbed. |
+| gaming | Sortable table with the click affordance on a descendant `span[onclick]` called static | Handler/focus affordance scanned in the whole header-cell subtree. |
+| gaming | ARIA grids (`role=grid` + `role=columnheader`) could never be capable; their `aria-sort` claim was inert | `col_header_cells` includes `role=columnheader`; gate and anti-circularity now identical for native and ARIA tables. |
+| gaming | Run-level DOM dominance buried genuinely divergent JS conventions on other screens | Card dominance is **per screen** (a screen's DOM grid demotes only that screen's JS hits). Dialog dominance stays run-level, mirroring frozen v1's pilot-calibrated `window.confirm` rule — difference documented. |
+| gaming | Two card conventions sharing one grid read as one (first-member signature + early return) | DOM lane groups by (tag, class token) **and then by full shape**; every qualifying shape in every group emits an instance. |
+| bias | Toast family charged the prescribed `status`/`alert` severity pair as dispersion (+1 floor on D-compliance) | Toasts **partitioned by announcement channel** (polite ≈ `role=status`/`aria-live=polite`, assertive ≈ `role=alert`/`aria-live=assertive`); dispersion measured within each channel (`role=status` vs `aria-live=polite` is still two conventions). |
+| bias | Nav family conflated landmark subtypes: a semantic footer `<nav>` cost +1 while a div-built footer was invisible | Navs **partitioned by slot**: the primary nav (most links, DOM order breaks ties) compared across screens; secondary navs pooled by normalized accessible name. The dropdown axis is now the *set* of mechanisms present. |
+| bias | JS-lane signatures embedded authoring artifacts (`js-template` vs `js-builder`, `interpolated-cover`) — identical rendered cards charged +1 | Signatures normalized to **rendered shape**: container axis from the receiving host element (same vocabulary as the DOM lane), interpolated image markup ≈ `img`, authoring style demoted to `style` metadata; indeterminate fragment-forest shapes stay instances but leave variant identity. |
+| regression | `bindings` regex matched *inside* template literals on minified JS (card family silently zeroed) | Offset-preserving `blank_code`: template literals + comments blanked for binding scans (plain-string ids kept); everything blanked for brace matching and iteration checks. Documented limit: JS regex literals are not recognized. |
+| regression | An unbound second factory scored (+1 spurious excess; the 2-signatures pattern occurs in 7/30 real runs) | Receiver resolution is **per factory** — only signatures whose own factory reaches a bound receiver are emitted. |
+| regression | `<template>` sample cards counted as live DOM (and then demoted the real JS grid) | `cards_dom` skips `template` subtrees. Inherited v1 detectors intentionally keep v1's judgments verbatim; template contents there remain a documented sensitivity note. |
+| regression | Every tag missing from `IMPLICIT` resolved to generic (`ul[role=menu] > a` passed while `> li` was excluded) | Same fix as the first gaming finding (one root cause, two lenses). |
+| regression | Arrow-function factories (`const X = (b) => …`) got no name; render sites after the unit were invisible | `_name_before` covers arrow assignments; `.map(name)`/`.join` render forms count as render sites. |
+| regression | Braces inside strings/comments truncated function units (factory vanished) | Brace matching runs on fully blanked text; unit bodies are recovered from the original offsets. |
+| bias | Cross-vocabulary confound: variant excess is only measurable inside the semantic vocabulary the standard prescribes, deflating A/B cells in **secondary** contrasts | Cannot be fixed in a static detector; fixed as an **analysis rule**: ruler 4 informs the *primary* contrast (D20 vs D18 — same vocabulary on both sides); in secondary contrasts (vs A/B) it is descriptive only, quoted per family, conditioned on the family being counted in both cells, denominator alongside, raw cross-condition sums barred from headlines. `analyze.py` enforces this (excess enters the contrast table only for D20 vs D18); `per_family_excess` is a top-level output so the per-family reading is the quotable one. The sensitivity table below carries the same warning. |
+
+### The second panel round's amendments (attacks on the fixes)
+
+All 13 confirmed findings fixed:
+
+| Lens | Finding | Fix |
+|---|---|---|
+| regression (**blocker**) | JS regex literals (`.replace(/"/g,…)` in a real run) opened a phantom string in the blanking pass — 4/30 runs misread, one B cell understated | The shared JS lexer recognizes regex literals (standard heuristic: a `/` whose previous token cannot end an expression; escapes and character classes handled; `}` stays ambiguous, documented). Verified by hand against the real file before fixing. |
+| gaming | A live-region wrapper around a live-region toast (belt-and-suspenders idiom in a real D run) was two "conventions" — the run's entire excess | `toasts()` collapses ancestor-descendant matches: the innermost element is the widget. Sensitivity re-baselined (antigravity D 10→9). |
+| gaming ×2 | Nested template literals — the top-frequency LLM catalog idiom (`grid.innerHTML = \`…${books.map(b => \`…\`)}…\``) — scored 0 cards | One real JS lexer replaces the regex tokenizer: template text, `${…}` interpolation code (recursive), strings, comments and regexes are tracked; literal collection includes nested template text AND interpolation markers, so both the nested-map idiom and the `${coverMarkup}` idiom survive. Top-level render code with no enclosing function scans as one pseudo-unit. |
+| gaming | Receiver forms: chained `getElementById('x').innerHTML = …` (no variable), `querySelector('.class')`, and hosts holding a skeleton/`noscript` placeholder all zeroed the family | All three added: chained no-variable receivers, `('class', name)` host keys, and a placeholder-tolerant near-empty test. |
+| gaming | A decorative `aria-hidden` SVG badge inside one card split a uniform grid into two conventions | `imageish` ranks real covers above svg and ignores `aria-hidden` svg entirely. |
+| gaming | A select-all checkbox (or filter input) with a handler inside a `th` opened the sort-capability gate | Form controls (checkbox/radio/textbox/listbox roles) are skipped by the handler/focus term — selection/filter affordances are not sort affordances. |
+| gaming + bias | Nav slots: a footer nav was promoted to "primary" on footer-only screens, and a breadcrumb was promoted when the main nav is client-rendered — false +1 on uniform runs, agent-correlated | Slot identity comes from the nav's own accessible name: named navs pool as `label:<name>` and are NEVER promoted; the link-richest unnamed nav is `unnamed-main`; remaining unnamed navs share `unnamed-other`. Sensitivity re-baselined (claude-code A 12→11). |
+| gaming (→minor) | Button-only forms — including a real D run's canonical `<form method="dialog">` confirm forms — were stubbed as contentless | A form with ≥1 field OR ≥1 button/submit control is substantive; only the empty shell stubs. |
+| bias | A counted card family whose every instance is shape-indeterminate reported a measured 0 excess and stayed in the denominator | `unmeasurable` flag: `per_family_excess = null`, excluded from the excess sum AND from `families_counted`; `families_unmeasurable` reported beside it. Fires on 5 real antigravity runs (fragment-forest factories) — cells now declared unmeasured instead of falsely zero. |
+| regression | A dead same-name factory in a second script borrowed the live factory's render sites (+1 spurious) | Name-based render-site resolution trusts a foreign script only when it does not define its own factory of that name. |
+| regression | Arrow-assigned factories and `.map(factory)` bare-callback render sites were invisible | `_name_before` covers arrow assignments; all render-site patterns accept bare-callback and `ns.name` forms plus spread-append. |
+| regression | Brace-matching and binding scans still confusable by literals in one path | All structural scans run over the lexer's blanked text; unit bodies recover from original offsets. |
+
+Confirmed as design, documented (no code change): invalidating a divergent
+instance lowers excess (intended: the error migrates to the violation
+rulers, and exclusions are reported per condition — a run cannot silently
+profit); breaking-markup-to-hide-dispersion is therefore visible in
+`excluded`, which the protocol reports beside every excess.
+
+Minor notes adopted across both rounds: bare/valueless `aria-sort` counts
+(presence, not truthiness); `scope` and `aria-live` values compare
+case-insensitively; a bare `th` in the table's first row (no thead, no
+scope) heads its column, so the gate does not depend on the thead idiom;
+missing fixture directories fail the self-test instead of skipping;
+nonexistent run paths report `status: missing` (an empty directory is
+`no-data`); the census regex gains Portuguese lexemes; the tautological
+denominator self-check was replaced by a falsifiable one (a one-screen
+family is not counted). Parser amendments (measured judgment-neutral on
+the whole Round-1 corpus, adopted for browser faithfulness): duplicate
+attributes keep the FIRST value; HTML5 optional end tags auto-close
+(`li`, `p`, `dt/dd`, `tr`, `td/th`, `option`), walking up through
+non-structural open elements and stopping at structural containers.
+
+## Principles
+
+1. **Condition-blind.** Input is a directory of `*.html` (plus local `js/`
+   files those screens reference). No run name, no condition label, no
+   network. Proven mechanically in the self-test (identical bytes under
+   A-named and D-named directories) — that probe is mandatory, not
+   skippable.
+2. **Deterministic.** Same input → same output; verified across re-runs,
+   hash seeds and `-O`.
+3. **Capability before state.** A run is never compared on a state signal
+   it has no occasion to emit.
+4. **Like with like.** Partitioned comparison — nav slots, toast channels,
+   table dimensions — so purpose splits (main vs footer nav, success vs
+   error announcement) are never read as dispersion.
+5. **Validity before variants.** A broken instance is evidence of a
+   *defect*, not a *convention*; excluded and counted.
+6. **Richness beside excess**, stubs apart. "Excess 0 over 3 families" and
+   "excess 0 over 6 families" are different claims.
+7. **Rendered shape, not authoring style.** How a card factory is written
+   is metadata; what it renders is identity.
+8. **No silent lanes.** Every instance carries `source`; demotions stay
+   visible (`cards_js_refs`, `script_confirm_refs`); stubs stay visible
+   (`stub_detail`).
+9. **Static-analysis honesty.** What static analysis cannot see is
+   documented below, never patched with speculative heuristics.
+
+## Family detectors
+
+`dialog` and `form` keep v1's judgments verbatim. `nav` and `toast` keep
+v1's signature vocabulary but partition the comparison pool. `table` and
+`card` are re-specified. Every DOM instance passes the validity gate and
+the substance predicate before entering variants.
+
+### Tables (case A)
+
+- **Structure dimension** — signature `(container, heads)` over all valid
+  tables.
+- **Capability** (`table_sortable`) — a table is sortable iff any *column
+  header cell* (a `th` with a `thead` ancestor or `scope=col`
+  case-insensitive, or any element with `role=columnheader`) has: (a) an
+  interactive descendant; or (b) a handler (`onclick`/`onkeydown`/
+  `onkeypress`), `role=button`, or non-negative `tabindex` anywhere in the
+  cell's subtree; or (c) a claim — the `aria-sort` attribute present
+  (value irrelevant) on any column header cell. Term (c) only ever adds.
+- **State dimension** — `sort_signal` per capable table: `aria-sort`
+  present anywhere in a column header cell's subtree. Family excess =
+  structure excess + state excess (when counted).
+
+### Cards (case B)
+
+- **DOM lane** — containers `ul|ol|div|section`; direct children grouped
+  by `(tag, first class token)` then by full shape `(item_shape, image,
+  action)`; each shape with ≥3 members is an instance. `imageish` accepts
+  `img|svg|picture` or a cover-classed `div|span|i`; innermost qualifying
+  container wins; `template` subtrees are inert; card items with no text
+  and no real image source anywhere are stubs.
+- **JS lane** — local scripts showing iteration; function units extracted
+  by brace-matching over literal/comment-blanked text; factories are
+  template/concat units whose concatenated literals parse into a
+  card-shaped fragment, or builder units creating `{img} ∧ {button|a} ∧
+  {article|li|div}`. A screen counts an instance **iff that factory's own
+  output** reaches a bound, (near-)empty grid container in the DOM —
+  named render sites, anonymous receiver zones, `.map(factory)` forms, and
+  depth-2 helper indirection; bindings resolve `getElementById`, `#id`
+  selectors and `[data-…]` attribute selectors. The instance's container
+  axis is the *host element's* tag, so both lanes share one vocabulary;
+  `style` (template/builder) is metadata.
+- **Dominance** — per screen: a screen with DOM-lane cards keeps its own
+  JS hits as metadata; other screens adopt theirs.
+
+### Validity gate (case C)
+
+Runs per instance, on its anchor's subtree, before signatures enter the
+variant sets. Composite containers (`menu`, `menubar`, `listbox`,
+`tablist`, `radiogroup`, `tree`, `table`, `grid`, `rowgroup`, `row`,
+`list`): direct children must resolve into the allowed set, where
+`role=none|presentation` delegates, *generic* elements are transparent
+(ARIA 1.2), `group` is transparent, `rowgroup`/`row` descend — and
+interactive elements resolve to their real implicit roles, so `div[role=
+menu]` full of plain links is as broken as `ul[role=menu] > li`. A
+composite with element content but no owned item anywhere is broken.
+Native content models (`ul/ol/dl/table`…) are checked when no role
+overrides them. Empty containers are vacuously valid; hidden subtrees ARE
+checked. Scope limits (documented, mirroring axe): a native container with
+a non-composite role (`ul[role=navigation]`) is checked by neither path;
+`aria-owns` is not resolved.
+
+### Partitions (like with like)
+
+- **Nav slots:** per screen, the nav with most links (`a[href]`) is
+  `primary` (ties: DOM order); the rest pool by normalized
+  `aria-label`/`aria-labelledby` (`sec:<label>`, or `sec:unnamedN`).
+  Excess = Σ per-partition (|variants| − 1). Chosen *before* the validity
+  gate, so an excluded primary does not promote a footer.
+- **Toast channels:** `polite` (`role=status`, `aria-live=polite`),
+  `assertive` (`role=alert`, `aria-live=assertive`), `other`. Excess
+  summed per channel.
+- Slot/channel identity depends only on the run's own DOM — no whitelist,
+  no condition knowledge.
+
+### Richness (case D)
+
+Sibling block: `families_instantiated`, `families_counted` (the
+denominator), `total_instances`, `coverage_cells`, `coverage_ratio`,
+`screens_multi_family`, `stub_instances`, `per_family` (instances,
+screens_with, stubs, `sources: {dom, script}`), `nonsemantic_candidates`
+(lexical census, EN+PT lexemes, metadata only). Substance predicates:
+table = any header/cell/caption content; dialog = children, text or
+naming; form = ≥1 real field; nav = ≥1 link; card = text or real image
+source; toast = always substantive (the empty placeholder is the correct
+idiom). Empty directories: `status: no-data`; nonexistent paths:
+`status: missing`.
+
+## Known limitations (documented, not patched)
+
+1. **Listener-only sort affordances** (`addEventListener` on a bare `th` —
+   2 real A runs): outside the state pool unless claimed via `aria-sort`.
+2. **Runtime-only `aria-sort`** (`setAttribute`): static capture shows
+   `signal=none`, uniformly.
+3. **Static rendering**: framework-rendered pages with no local factory
+   source stay invisible to both lanes.
+4. **JS lexer ambiguities**: a `/` right after `}` is read as possible
+   division, never a regex start (regex literals elsewhere are handled);
+   namespace/object-method factories and helper chains deeper than 2 stay
+   invisible (executed proof in the panel's notes).
+5. **`<template>` contents** in the four inherited v1 detectors (dialog,
+   nav, form, toast) follow v1's judgment (not skipped) — kept verbatim
+   for cross-round comparability; a sensitivity note, not a fix.
+6. **`ul` with a non-composite role** escapes the native content-model
+   check (mirrors axe).
+7. **Lexical census** can miss unconventionally named fakes; never a
+   metric.
+8. **Nav substance requires a link** (`a[href]`): an empty client-rendered
+   `<nav>` stubs while a thead-only table earns static credit — an
+   asymmetry kept deliberately (a nav's minimum substance is navigation)
+   and reported via `stub_detail` either way.
+9. **Gaming by an instrument-aware author** (e.g. shape-indeterminate
+   factories to dodge variant identity) is out of threat model: study
+   agents are condition-blind and instrument-blind; the panel's residual
+   gaming notes are recorded in its report.
+
+## Self-test
+
+`classifier_v2.py --self-test` (58 checks, all mandatory — missing
+fixtures fail): the 15 empty codex directories as no-data and missing-path
+as `missing`; case A on the real corpus (zero state excess, 10/10 D tables
+counted); case C surgical exclusion (7 in one run, 0 elsewhere); case B
+30/30 detection with exactly 5 DOM-lane runs; the calibration pair's
+measured richness (4/17/17 vs 6/32/23) and census; mechanical
+condition-blindness; 27 held-out counterfactuals from calibration and the
+first panel round (divergent signals +1, span-onclick capability,
+ARIA-grid capability, broken/delegated/div-link ladders, zero-item
+composites, css-cover, JS template, authoring-style equivalence,
+mixed-grid +1, dead factory, minified JS, arrow factory, brace-in-string,
+inert template, per-screen dominance, dual-severity 0, channel divergence
++1, nav partition 0/+1, stubs beside the denominator, poverty beside a
+zero excess); and 15 more from the second round (nested live-region = one
+widget, case-insensitive `aria-live`, nested-template idiom, chained and
+class-selector receivers, placeholder-tolerant hosts, name-collision
+scoping, decorative-svg immunity, all-indeterminate → unmeasurable,
+regex-literal survival, checkbox-in-th immunity, bare-th gate symmetry,
+button-only form substance, footer-only screens, and a falsifiable
+denominator check).
+
+## Sensitivity: v1 → v2 on Round 1's corpus
+
+v1 remains frozen and runnable; the registered analysis reports both.
+**Reading rule (per the cross-vocabulary confound):** cross-condition
+comparisons of these sums are only safe within the same vocabulary
+(D vs D); the A/B columns are shown for instrument transparency, with
+`families_counted` medians alongside in the registered output — never as
+a standalone contrast.
+
+| Cell | v1 | v2 | Exclusions | Stubs | Unmeasurable | Reading |
+|---|---|---|---|---|---|---|
+| antigravity A | 0 | 2 | 0 | 0 | 0 | the "consistency by poverty" zero was blindness — JS-rendered cards reveal real dispersion (denominator: 3–4 families) |
+| antigravity B | 20 | 11 | 0 | 0 | 2 | toast-channel partition removes the status/alert purpose split; 2 card cells declared unmeasurable (fragment-forest factories), not zero |
+| antigravity D | 21 | 9 | 7 | 0 | 3 | `aria-sort` no longer punished; run3's ladder moves to exclusion; the nested live-region widget is one instance, not two |
+| claude-code A | 21 | 11 | 0 | 3 | 0 | nav pooling by accessible name removes footer-vs-main false dispersion |
+| claude-code B | 18 | 11 | 0 | 1 | 0 | +1 vs the first draft: the regex-literal fix RESTORED a real dispersion point the corrupted blanking had hidden |
+| claude-code D | 18 | 7 | 0 | 0 | 0 | +1 vs the first draft: button-only confirm forms back in the pool with their real dispersion |
+
+Shifts run in both directions and track *content*; the instrument has no
+way to know the condition. Note the last two rows: the second panel
+round's fixes RAISED both claude-code non-A cells — hardening the
+instrument twice moved numbers against and in favor of every condition at
+different points, which is what a condition-blind instrument under honest
+repair looks like.
+
+## Freeze procedure
+
+1. ~~Adversarial verification~~ — done twice (rounds 1 and 2 above); every
+   confirmed finding fixed or documented.
+2. `sha256sum classifier_v2.py` recorded here and in the OSF registration
+   package at protocol freeze; the fixtures directory hashed alongside.
+3. After the freeze, any change is a dated `DEVIATIONS.md` entry — same
+   discipline as every other Round 2 instrument.

--- a/benchmark/round2/PROTOCOL-DRAFT.md
+++ b/benchmark/round2/PROTOCOL-DRAFT.md
@@ -125,7 +125,7 @@ near-complete separation is distinguishable from noise.
 | 1 | **Screens with error** — screen×error pairs, axe critical+serious. *Construct qualified: the machine-detectable layer only (axe-class coverage 30–57% in the literature, cited in the registration).* | the person navigating | `rulers.py screens` |
 | 2 | **Wrong decisions** — distinct violated rules per journey (each error counted once however often its mold repeats). Definition frozen in `RULERS.md`, validated in `--self-test` against Round 1's published 9/11/8. | the maintainer fixing | `rulers.py decisions` |
 | 3 | **Clean journeys** — descriptive only, base rates printed (Round 1: 0/5 · 0/5 · 2/5 on the small model). | the team shipping | `rulers.py clean` |
-| 4 | **Consistency v2** — see spec direction below; frozen as `classifier-v2.py`. The frozen v1 (hash intact) runs over all Round-2 data as a **sensitivity analysis**; both results published; divergence reported as a finding about the instrument. | the person relearning each screen | `classifier-v2.py` |
+| 4 | **Consistency v2** — see spec direction below; frozen as `classifier_v2.py` (underscore: `analyze.py` and the self-test import it as a module — a filename detail settled before the freeze, noted here so the draft's earlier `classifier-v2.py` spelling has a paper trail). The frozen v1 (hash intact) runs over all Round-2 data as a **sensitivity analysis**; both results published; divergence reported as a finding about the instrument. | the person relearning each screen | `classifier_v2.py` |
 | 5 | **Flagged elements** — raw node count (registered since Round 1). | the auditor | axe + `analyze.py` |
 
 All rulers 1–3 ship as **frozen scripts with `--self-test`** whose fixtures
@@ -194,6 +194,15 @@ these constraints, panel-reviewed:
   dispersion, and the card detector blind in 27/30 runs of a bookstore.
 - The frozen **v1 runs over all Round-2 data as sensitivity analysis** (cost:
   seconds; gain: cross-round auditability).
+- **Cross-vocabulary rule (adversarial panel, bias lens):** variant excess is
+  only measurable inside the semantic vocabulary the standard prescribes —
+  non-semantic A/B implementations of the same components disperse invisibly.
+  Ruler 4 therefore informs the **primary contrast only** (D20 vs D18, same
+  vocabulary on both sides). In secondary contrasts (vs A/B) it is
+  descriptive: quoted per family, conditioned on the family being counted in
+  both cells, `families_counted` alongside, and raw cross-condition sums
+  barred from headlines. `analyze.py` enforces this mechanically (excess is
+  absent from the secondary contrast tables).
 
 ## Instrument discipline
 
@@ -237,7 +246,7 @@ quota walls set the pace, cut rule declared.
 - [ ] Rulers 1–3: `RULERS.md` definitions + `rulers.py` frozen by hash,
       `--self-test` reproducing Round 1's published numbers (33/13/38 ·
       9/11/8 · 0-0-2/5) and containing a D-loses fixture per ruler
-- [ ] Ruler v2: `CLASSIFIER-v2.md` + `classifier-v2.py` frozen by hash,
+- [ ] Ruler v2: `CLASSIFIER-v2.md` + `classifier_v2.py` frozen by hash,
       condition-blind principles + held-out counter-fixtures in `--self-test`
 - [ ] Kill-criterion class list derivation published (axe 4.13.0 structural
       rules; native and keyboard boundaries resolved)

--- a/benchmark/round2/RULERS.md
+++ b/benchmark/round2/RULERS.md
@@ -1,0 +1,105 @@
+# Rulers 1–3 & 5 — frozen definitions, and the kill-class derivation
+
+> Status: **draft — frozen when the protocol freezes; hashes recorded here.**
+> Executable judge: `rulers.py` (stdlib-only). Its `--self-test` reproduces
+> every Round-1 published number cited below from the published dataset —
+> a definition that cannot reproduce the published reading is a defect in the
+> definition, found before the freeze. Ruler 4 (consistency) is specified
+> separately in `CLASSIFIER-v2.md`.
+
+Impact filter for all rulers: axe **critical + serious**, axe-core 4.13.0
+(frozen with the verifier). Run unit: one journey = one 7-screen session,
+`agent__journey__COND__runN`.
+
+## Ruler 1 — screens with error (`rulers.py screens`)
+
+**Serves:** the person navigating. Each distinct violated rule counted once
+per screen it appears on (screen×error pairs), summed per condition.
+*Construct qualified in the registration: the machine-detectable layer only
+(axe-class coverage 30–57% in the literature).*
+Self-test anchor: Round 1 antigravity A/B/D = **33/13/38** — including the
+D-loses fixture (D 38 > B 13) the protocol requires.
+
+## Ruler 2 — wrong decisions (`rulers.py decisions`)
+
+**Serves:** the maintainer fixing. Distinct violated rules **per journey**,
+summed per condition. Each journey is an independent project: the same wrong
+rule in two journeys is two decisions; within a journey it is one, however
+many screens repeat its mold.
+Self-test anchor: antigravity A/B/D = **9/11/8**. This is the ruler whose
+prose definition drifted in Round 1's write-up; the executable definition
+above is the one that reproduces the published table, frozen here.
+
+## Ruler 3 — clean journeys (`rulers.py clean`)
+
+**Serves:** the team shipping. Journeys with zero critical+serious
+violations, per condition. **Descriptive only** — base rates printed, never
+a contrast headline. Self-test anchor: antigravity A/B/D = **0/5, 0/5, 2/5**.
+
+## Ruler 5 — flagged elements (`rulers.py elements`)
+
+**Serves:** the auditor. Total flagged nodes (critical+serious), per
+condition. Registered since Round 1. Self-test anchors: antigravity A/B/D =
+**167/42/144**; claude-code = **369/0/0** — the antigravity D-loses fixture
+(D 144 > B 42) again in the suite.
+
+## The floor panel (`rulers.py floors`)
+
+Per-obligation classes (axe rule ids, frozen):
+
+- `image-alt`: `image-alt`, `input-image-alt`, `role-img-alt`, `svg-img-alt`, `area-alt`
+- `label`: `label`, `select-name`, `form-field-multiple-labels`, `aria-input-field-name`
+- `color-contrast`: `color-contrast`
+
+Read by `analyze.py` under the canonical panel's rules (floors, the contrast
+bet). Self-test anchors: contrast in 3/5 antigravity D journeys, 0/5
+claude-code D; image-alt and label at zero in all D journeys.
+
+## Kill-criterion class list — derivation (axe-core 4.13.0)
+
+The kill criterion operationalizes v2.0.0 §6's anti-pattern **Half-Climbed
+ARIA Ladders**: a composite pattern *announced* (a container role or a
+role-bearing item) whose required structural rungs are *not completed*. The
+class list is every axe 4.13.0 rule whose failure condition is exactly
+"announced structure, missing rung" — nothing else:
+
+| Rule | Rung it detects | Why it is the same ladder |
+|---|---|---|
+| `aria-required-parent` | role-bearing child outside its required container | the child announces a composite pattern the parent never completed (Round 1's real instance: `li` with implicit `listitem` inside `role="menu"`) |
+| `aria-required-children` | composite container without its required owned children | the container announces the pattern and stops climbing (Round 1: the 7-screen children rule) |
+| `listitem` | `li` outside `ul`/`ol` | the native-HTML rung of the same ladder — list announced by the item, container missing |
+| `dlitem` | `dt`/`dd` outside `dl` | native rung, description lists |
+| `definition-list` | `dl` with invalid children | native rung, container side |
+| `aria-required-attr` | role announced without its required state attributes | the *attribute* rung: `role="checkbox"` without `aria-checked` is the same half-climb, in state rather than structure |
+
+**Boundaries, resolved (the two the protocol names):**
+
+- **Native rules are IN.** `listitem`, `dlitem`, `definition-list` flag the
+  identical defect expressed without ARIA. Excluding them would let a run
+  fail the ladder in plain HTML and pass the kill — a loophole, not a
+  boundary. (ARIA 1.2's generic-transparency rule means intermediate
+  wrapper `div`s do not trigger any of these — no false ladder from
+  legitimate wrappers; the consistency ruler's validity gate applies the
+  same reading.)
+- **Keyboard/behavior rules are OUT.** Rules like `nested-interactive`,
+  focus-order or key-handling failures are *behavioral* defects of a
+  completed structure, not an announced-but-unfinished structure. §6's
+  anti-pattern is structural; the kill class stays structural. Behavioral
+  failures remain fully counted by rulers 1/2/5 — out of the *kill*, not out
+  of the study.
+- Also considered and excluded: `aria-allowed-attr`, `aria-valid-attr-value`,
+  `aria-roles` (wrong usage, not incomplete announced structure) and
+  `list`/`aria-allowed-role` (container-side wrong-usage variants). Each is
+  still counted by rulers 1/2/5 at its own impact level.
+
+**Application (verbatim from the protocol):** binary; zero appearances of the
+class in all D20 `verify/*.jsonl`, reported WITH the 2×2 table against D18
+fresh (if D18 also zeroes, the zero evidences the client era, not §6 —
+stated). Base rate printed: 1/10 Round-1 D journeys carried the ladder;
+P(zero in 10 | no change) = 0.9¹⁰ ≈ 0.35. Judge: `rulers.py kill` +
+`analyze.py` panel.
+
+## Freeze
+
+`sha256sum rulers.py` and this file's hash enter the registration package.
+After the freeze, any change is a dated `DEVIATIONS.md` entry.

--- a/benchmark/round2/analyze.py
+++ b/benchmark/round2/analyze.py
@@ -1,0 +1,441 @@
+#!/usr/bin/env python3
+"""
+analyze.py — Round 2 registered analysis. Instrumentation for
+PROTOCOL-DRAFT.md: every judgment here is dictated by the protocol's
+outcomes section and canonical panel; this file adds none.
+
+Descriptive and estimation-oriented by declaration — point estimates, seeded
+bootstrap intervals (resampling BY JOURNEY CLUSTER — screens within a session
+are correlated), Cliff's delta, no p-values. Primary contrast: D20 vs D18,
+same-agent, never pooled. Secondary: D20 vs B, D20 vs A.
+
+Outcomes per journey, all via frozen instruments:
+  ruler1  screen×error pairs        (axe critical+serious; rulers.py judgment)
+  ruler2  distinct wrong decisions  (per journey; rulers.py judgment)
+  ruler5  flagged nodes             (rulers.py judgment)
+  excess_v2 + families_counted      (classifier_v2 — quoted only as a pair)
+  excess_v1                         (frozen v1, sensitivity analysis)
+  fresh/total tokens per screen     (explicit per-schema field lists — the
+                                     defect-#4 discipline, carried forward)
+Panel (canonical mapping, same-agent, two-agent adjudication — the LESS
+favorable verdict leads): floors (image-alt, label), generalized floors,
+the contrast bet, the governance pair, the kill criterion with its 2×2.
+
+    python3 analyze.py            # reads ../runs/round2, writes analysis.json
+    python3 analyze.py --self-test  # synthetic 40-run fixture, planted numbers
+
+Stdlib only. Ruler 3 (clean journeys) is printed as base rates, descriptive.
+"""
+import argparse, json, random, statistics, sys
+from collections import defaultdict
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+REPO = HERE.parent.parent
+OUT = REPO / "benchmark" / "runs" / "round2"
+SEED = 20260921
+B = 10_000
+CONDITIONS = ("A", "B", "D18", "D20")
+CONTRASTS = (("D20_vs_D18", "D20", "D18"),   # primary
+             ("D20_vs_B", "D20", "B"), ("D20_vs_A", "D20", "A"))
+METRICS = ("ruler1", "ruler2", "ruler5", "excess_v2", "excess_v1",
+           "fresh_per_screen", "total_per_screen")
+# Ruler-4 cross-vocabulary rule (classifier panel, bias lens): variant excess
+# is only measurable inside the semantic vocabulary the standard prescribes,
+# so it enters the CONTRAST table only where both cells share that vocabulary
+# — the primary D20 vs D18. In secondary contrasts (vs A/B) it stays in the
+# per-condition medians as descriptive data, families_counted beside it,
+# never as a contrast estimand.
+VOCABULARY_BOUND = ("excess_v2", "excess_v1")
+
+sys.path.insert(0, str(HERE))
+sys.path.insert(0, str(REPO / "benchmark" / "study2"))
+from rulers import KILL_CLASS, FLOOR_CLASSES, parse_run, serious_violations  # noqa: E402
+from classifier_v2 import classify as classify_v2  # noqa: E402
+from classifier import classify as classify_v1  # noqa: E402
+
+
+# ---- per-journey outcomes (rulers' judgments, journey grain) ----
+
+def journeys(out_dir: Path):
+    """Retained journeys from the collection log (latest record per id wins)."""
+    seen = {}
+    for line in (out_dir / "log.jsonl").read_text().splitlines():
+        r = json.loads(line)
+        seen[r["id"]] = r
+    return {k: v for k, v in seen.items() if v.get("retained")}
+
+
+def verify_outcomes(out_dir: Path, rid: str):
+    screens = parse_run(out_dir / "verify" / f"{rid}.jsonl")
+    pairs = sum(len(serious_violations(s)) for s in screens)
+    decisions = len({v["id"] for s in screens for v in serious_violations(s)})
+    nodes = sum(v.get("nodes", 0) for s in screens for v in serious_violations(s))
+    clean = not any(serious_violations(s) for s in screens)
+    kill_nodes = sum(v.get("nodes", 0) for s in screens
+                     for v in s.get("violations", []) if v["id"] in KILL_CLASS)
+    floors_hit = {cls for s in screens for v in s.get("violations", [])
+                  for cls, ids in FLOOR_CLASSES.items()
+                  if v["id"] in ids and v.get("nodes", 0) > 0}
+    zero_classes_pool = {v["id"] for s in screens for v in serious_violations(s)}
+    return {"ruler1": pairs, "ruler2": decisions, "ruler5": nodes, "clean": clean,
+            "kill_nodes": kill_nodes, "floors_hit": floors_hit,
+            "violated_classes": zero_classes_pool}
+
+
+def token_outcomes(out_dir: Path, rid: str, n_screens: int = 7):
+    u = json.loads((out_dir / "raw" / f"{rid}.json").read_text() or "{}").get("usage", {})
+    # Defect-#4 discipline (Study 2, DEVIATIONS.md 2026-08-24): explicit
+    # per-schema field lists — the Antigravity client reports total_tokens
+    # (= input + output) ALONGSIDE its components; never sum by field-name.
+    if "total_tokens" in u:  # antigravity client schema
+        cache = u.get("cache_read_tokens", 0)
+        fresh = (u.get("input_tokens", 0) + u.get("output_tokens", 0)
+                 + u.get("thinking_tokens", 0))
+    else:                    # claude-code client schema
+        cache = u.get("cache_read_input_tokens", 0)
+        fresh = (u.get("input_tokens", 0) + u.get("output_tokens", 0)
+                 + u.get("cache_creation_input_tokens", 0))
+    return {"fresh_per_screen": fresh / n_screens,
+            "total_per_screen": (fresh + cache) / n_screens}
+
+
+def consistency_outcomes(out_dir: Path, rid: str):
+    r2 = classify_v2(out_dir / "screens" / rid)
+    r1 = classify_v1(out_dir / "screens" / rid)
+    if r2.get("status") != "ok":
+        return {"excess_v2": None, "families_counted": None, "excess_v1": None}
+    return {"excess_v2": r2["variant_excess"],
+            "families_counted": r2["richness"]["families_counted"],
+            "excess_v1": r1["variant_excess"]}
+
+
+def governance(out_dir: Path, rid: str):
+    names = [p.name.lower() for p in (out_dir / "screens" / rid).rglob("*.md")]
+    return {"report": any("report" in n for n in names),
+            "decisions": any("decisions" in n for n in names)}
+
+
+# ---- estimation (journey = the resampling cluster) ----
+
+def bootstrap_median_diff(x, y, seed=SEED):
+    rng = random.Random(seed)
+    diffs = []
+    for _ in range(B):
+        xs = [rng.choice(x) for _ in x]
+        ys = [rng.choice(y) for _ in y]
+        diffs.append(statistics.median(xs) - statistics.median(ys))
+    diffs.sort()
+    return diffs[int(B * 0.025)], diffs[int(B * 0.975)]
+
+
+def cliff(x, y):
+    gt = sum(1 for a in x for b in y if a > b)
+    lt = sum(1 for a in x for b in y if a < b)
+    return (lt - gt) / (len(x) * len(y))   # positive = x typically smaller
+
+
+def wilson95(k, n):
+    if n == 0: return [0.0, 0.0]
+    z = 1.959964
+    p = k / n
+    d = 1 + z * z / n
+    c = (p + z * z / (2 * n)) / d
+    h = z * ((p * (1 - p) / n + z * z / (4 * n * n)) ** 0.5) / d
+    return [round(max(0.0, c - h), 3), round(min(1.0, c + h), 3)]
+
+
+# ---- the canonical panel (verbatim rules from the protocol table) ----
+
+FAVOR = {  # adjudication order: index 0 is the LEAST favorable verdict
+    "floors": ("regression", "isolated-inspect", "pass"),
+    "contrast": ("refuted", "not-corroborated", "corroborated"),
+    "kill": ("fail", "pass"),
+}
+
+def floor_verdict(journeys_affected: int) -> str:
+    if journeys_affected == 0: return "pass"
+    if journeys_affected == 1: return "isolated-inspect"
+    return "regression"
+
+def contrast_verdict(d18_affected: int, d20_affected: int) -> str:
+    if d20_affected > d18_affected: return "refuted"
+    if (d18_affected > 0 and d20_affected < d18_affected) or (d18_affected == 0 and d20_affected == 0):
+        return "corroborated"
+    return "not-corroborated"   # tie at >0
+
+def panel_for_agent(vouts: dict):
+    """vouts: {cond: {rid: verify_outcomes}} for one agent."""
+    d20, d18 = vouts.get("D20", {}), vouts.get("D18", {})
+    out = {}
+    for cls in ("image-alt", "label"):
+        affected = sum(1 for o in d20.values() if cls in o["floors_hit"])
+        out[f"floor_{cls}"] = {"d20_journeys_affected": affected,
+                               "verdict": floor_verdict(affected)}
+    c18 = sum(1 for o in d18.values() if "color-contrast" in o["floors_hit"])
+    c20 = sum(1 for o in d20.values() if "color-contrast" in o["floors_hit"])
+    out["contrast_bet"] = {"d18_journeys_affected": c18, "d20_journeys_affected": c20,
+                           "verdict": contrast_verdict(c18, c20)}
+    if d18:
+        all18 = set().union(*(o["violated_classes"] for o in d18.values())) if d18 else set()
+        all20 = set().union(*(o["violated_classes"] for o in d20.values())) if d20 else set()
+        candidates = all20 - all18
+        reappeared = {cls: sum(1 for o in d20.values() if cls in o["violated_classes"])
+                      for cls in candidates}
+        regressions = {c: n for c, n in reappeared.items() if n >= 2}
+        out["generalized_floor"] = {
+            "classes_regressed": regressions,
+            "isolated": {c: n for c, n in reappeared.items() if n == 1},
+            "verdict": "regression" if regressions else (
+                "isolated-inspect" if any(n == 1 for n in reappeared.values()) else "pass")}
+    kill20 = sum(1 for o in d20.values() if o["kill_nodes"] > 0)
+    kill18 = sum(1 for o in d18.values() if o["kill_nodes"] > 0)
+    out["kill_criterion"] = {
+        "verdict": "pass" if kill20 == 0 else "fail",
+        "two_by_two": {"d18_journeys_with_ladder": kill18, "d18_n": len(d18),
+                       "d20_journeys_with_ladder": kill20, "d20_n": len(d20)}}
+    return out
+
+
+def adjudicate(panels: dict):
+    """Two-agent rule: report both; the LESS favorable verdict leads."""
+    led = {}
+    for check in set().union(*(p.keys() for p in panels.values())):
+        verdicts = {a: p[check]["verdict"] for a, p in panels.items() if check in p}
+        kind = ("contrast" if check == "contrast_bet"
+                else "kill" if check == "kill_criterion" else "floors")
+        order = FAVOR[kind]
+        lead = min(verdicts.values(), key=order.index)
+        led[check] = {"per_agent": verdicts, "leads": lead}
+    return led
+
+
+# ---- main ----
+
+def analyze(out_dir: Path):
+    recs = journeys(out_dir)
+    data = defaultdict(lambda: defaultdict(dict))     # agent -> cond -> rid -> outcomes
+    vdata = defaultdict(lambda: defaultdict(dict))    # verify outcomes (panel inputs)
+    gov = defaultdict(lambda: defaultdict(dict))
+    versions = defaultdict(set)
+    for rid, rec in sorted(recs.items()):
+        agent, _, cond, _ = rid.split("__")
+        v = verify_outcomes(out_dir, rid)
+        o = {**{k: v[k] for k in ("ruler1", "ruler2", "ruler5", "clean")},
+             **token_outcomes(out_dir, rid),
+             **consistency_outcomes(out_dir, rid)}
+        data[agent][cond][rid] = o
+        vdata[agent][cond][rid] = v
+        gov[agent][cond][rid] = governance(out_dir, rid)
+        versions[(agent, rec.get("agent_version", "?"))].add(cond)
+
+    report = {"seed": SEED, "bootstrap": B, "resampling_unit": "journey cluster",
+              "posture": "descriptive and estimation-oriented — not confirmatory at this n",
+              "agents": {}, "panel": {}, "version_by_condition": {
+                  f"{a} · {v}": sorted(c) for (a, v), c in sorted(versions.items())}}
+
+    panels = {}
+    for agent, conds in sorted(data.items()):
+        block = {"n": {c: len(v) for c, v in sorted(conds.items())},
+                 "medians": {}, "clean_journeys": {}, "contrasts": {}}
+        for c, v in sorted(conds.items()):
+            vals = list(v.values())
+            block["medians"][c] = {
+                m: (statistics.median(o[m] for o in vals) if all(o[m] is not None for o in vals) else None)
+                for m in METRICS}
+            block["medians"][c]["families_counted"] = (
+                statistics.median(o["families_counted"] for o in vals)
+                if all(o["families_counted"] is not None for o in vals) else None)
+            block["clean_journeys"][c] = f"{sum(1 for o in vals if o['clean'])}/{len(vals)}"
+        for label, hi, lo in CONTRASTS:
+            if hi not in conds or lo not in conds: continue
+            entry = {}
+            metrics = METRICS if lo.startswith("D") else tuple(
+                m for m in METRICS if m not in VOCABULARY_BOUND)
+            for m in metrics:
+                x = [o[m] for o in conds[hi].values()]
+                y = [o[m] for o in conds[lo].values()]
+                if any(v is None for v in x + y): continue
+                ci = bootstrap_median_diff(x, y)
+                entry[m] = {"median_diff": round(statistics.median(x) - statistics.median(y), 2),
+                            "ci95": [round(ci[0], 1), round(ci[1], 1)],
+                            "cliff": round(cliff(x, y), 2)}
+            block["contrasts"][label] = entry
+        g20 = list(gov[agent].get("D20", {}).values())
+        pair = sum(1 for g in g20 if g["report"] and g["decisions"])
+        others = [g for c in ("A", "B") for g in gov[agent].get(c, {}).values()]
+        block["governance"] = {
+            "d20_pair": f"{pair}/{len(g20)}", "d20_ci95": wilson95(pair, len(g20)),
+            "ab_pair": f"{sum(1 for g in others if g['report'] and g['decisions'])}/{len(others)}"}
+        panels[agent] = panel_for_agent(vdata[agent])
+        panels[agent]["governance_pair"] = {
+            "verdict": "pass" if pair == len(g20) and g20 else
+                       ("isolated-inspect" if pair == len(g20) - 1 else "regression"),
+            "d20_pair": f"{pair}/{len(g20)}"}
+        report["agents"][agent] = block
+
+    report["panel"] = {"per_agent": panels, "adjudication": adjudicate(panels)}
+    return report
+
+
+def main():
+    report = analyze(OUT)
+    (OUT / "analysis.json").write_text(json.dumps(report, indent=1, ensure_ascii=False))
+    for agent, blk in report["agents"].items():
+        print(f"== {agent} · n {blk['n']} · clean {blk['clean_journeys']}")
+        for lbl, e in blk["contrasts"].items():
+            if "ruler1" in e:
+                line = (f"   {lbl}: ruler1 Δ{e['ruler1']['median_diff']:+.0f} IC{e['ruler1']['ci95']} "
+                        f"Cliff {e['ruler1']['cliff']:+.2f}")
+                if "excess_v2" in e:
+                    line += (f" · excess_v2 Δ{e['excess_v2']['median_diff']:+.0f} "
+                             f"Cliff {e['excess_v2']['cliff']:+.2f}")
+                print(line)
+    print("panel (less favorable leads):")
+    for check, v in sorted(report["panel"]["adjudication"].items()):
+        print(f"   {check}: {v['per_agent']} -> leads: {v['leads']}")
+
+
+# ---------------------------------------------------------------------------
+# --self-test: synthetic 40-run fixture with planted numbers
+# ---------------------------------------------------------------------------
+
+SCREENS7 = ("index", "search", "book", "cart", "sell", "dashboard", "orders")
+
+def _mk_verify(path, rows):
+    lines = []
+    for sid, viols in rows:
+        lines.append(json.dumps({"id": sid, "violations": viols}))
+    path.write_text("\n".join(lines) + "\n")
+
+def _viol(vid, nodes, impact="serious"):
+    return {"id": vid, "impact": impact, "nodes": nodes}
+
+def build_fixture(root: Path):
+    """40 runs, 2 agents × 4 conditions × 5. Planted so every panel branch
+    and every contrast sign is known in advance.
+      fake-clean  : D20 wins everything (contrast corroborated, kill pass
+                    with an informative 2×2, floors pass, governance 5/5)
+      fake-dirty  : the unfavorable twin (contrast refuted, kill fail,
+                    image-alt floor regression, governance 3/5)"""
+    (root / "raw").mkdir(parents=True); (root / "verify").mkdir(); (root / "screens").mkdir()
+    log = []
+    nav = ('<nav aria-label="Main"><ul><li><a href="index.html">Home</a></li>'
+           '<li><a href="search.html">Search</a></li><li><a href="cart.html">Cart</a></li>'
+           '</ul></nav>')
+    for agent in ("fake-clean", "fake-dirty"):
+        for cond in CONDITIONS:
+            for run in range(1, 6):
+                rid = f"{agent}__journey__{cond}__run{run}"
+                d = root / "screens" / rid; d.mkdir()
+                for s in SCREENS7:
+                    (d / f"{s}.html").write_text(
+                        f'<!doctype html><html lang="en"><body>{nav}<main><h1>{s}</h1></main></body></html>')
+                base = {"A": 20, "B": 10, "D18": 6, "D20": 2}[cond]
+                viols = [("index", [_viol("link-name", base + run)]),
+                         ("search", [_viol("region", 2)] if cond in ("A", "B") else [])]
+                if agent == "fake-clean":
+                    if cond == "D18" and run <= 3:
+                        viols.append(("cart", [_viol("color-contrast", 3)]))
+                    if cond == "D18" and run == 2:
+                        viols.append(("sell", [_viol("aria-required-children", 4, "critical")]))
+                    if cond == "D20":
+                        viols = [("index", [_viol("color-contrast", 0)])]  # zero nodes = not affected
+                        viols.append(("search", []))
+                else:
+                    if cond == "D18" and run == 1:
+                        viols.append(("cart", [_viol("color-contrast", 3)]))
+                    if cond == "D20" and run <= 3:
+                        viols.append(("cart", [_viol("color-contrast", 5)]))
+                    if cond == "D20" and run == 1:
+                        viols.append(("sell", [_viol("listitem", 2, "critical")]))
+                    if cond == "D20" and run <= 2:
+                        viols.append(("book", [_viol("image-alt", 1, "critical")]))
+                _mk_verify(root / "verify" / f"{rid}.jsonl",
+                           [(s, next((v for n, v in viols if n == s), [])) for s in SCREENS7])
+                if agent == "fake-clean":
+                    usage = {"input_tokens": 1000 * base, "output_tokens": 400,
+                             "cache_creation_input_tokens": 100, "cache_read_input_tokens": 7000}
+                else:  # antigravity-style schema: total_tokens must NOT be summed
+                    usage = {"total_tokens": 1400 * base, "input_tokens": 1000 * base,
+                             "output_tokens": 400 * base, "thinking_tokens": 0,
+                             "cache_read_tokens": 7000}
+                (root / "raw" / f"{rid}.json").write_text(json.dumps({"usage": usage}))
+                if cond == "D20" and not (agent == "fake-dirty" and run > 3):
+                    (d / "REPORT.md").write_text("# report\n")
+                    (d / "A11Y-DECISIONS.md").write_text("# decisions\n")
+                log.append({"id": rid, "agent": agent, "condition": cond, "run": run,
+                            "attempt": 1, "agent_version": "fake 1.0.0",
+                            "screens": 7, "retained": True, "files_created": []})
+    (root / "log.jsonl").write_text("\n".join(json.dumps(r) for r in log) + "\n")
+
+
+def self_test():
+    import tempfile
+    ok = True
+    def check(name, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {name}: got {got!r} want {want!r} {'ok' if good else 'SELF-TEST FAILURE'}")
+
+    td = Path(tempfile.mkdtemp(prefix="round2-analyze-selftest-"))
+    build_fixture(td)
+    rep1 = analyze(td)
+    rep2 = analyze(td)
+    print("determinism — same fixture, same seed, same report:")
+    check("byte-identical reports", json.dumps(rep1, sort_keys=True) == json.dumps(rep2, sort_keys=True), True)
+
+    print("planted contrasts (fake-clean): D20 beats D18, sign and magnitude:")
+    c = rep1["agents"]["fake-clean"]["contrasts"]["D20_vs_D18"]
+    check("ruler5 Cliff = +1.0 (all D20 < all D18)", c["ruler5"]["cliff"], 1.0)
+    check("ruler1 median_diff negative", c["ruler1"]["median_diff"] < 0, True)
+    check("fresh tokens: D20 cheaper (schema fields, not name-matching)",
+          c["fresh_per_screen"]["median_diff"] < 0, True)
+    check("excess_v2 present with families_counted beside it",
+          rep1["agents"]["fake-clean"]["medians"]["D20"]["families_counted"] is not None, True)
+    check("ruler-4 vocabulary rule: excess in the primary contrast only",
+          ("excess_v2" in rep1["agents"]["fake-clean"]["contrasts"]["D20_vs_D18"],
+           "excess_v2" in rep1["agents"]["fake-clean"]["contrasts"]["D20_vs_B"],
+           "excess_v2" in rep1["agents"]["fake-clean"]["contrasts"]["D20_vs_A"]),
+          (True, False, False))
+
+    print("planted panel — fake-clean (the favorable twin):")
+    p = rep1["panel"]["per_agent"]["fake-clean"]
+    check("contrast bet corroborated (3 -> 0)", p["contrast_bet"]["verdict"], "corroborated")
+    check("kill pass with informative 2x2 (D18 had the ladder)",
+          (p["kill_criterion"]["verdict"], p["kill_criterion"]["two_by_two"]["d18_journeys_with_ladder"]),
+          ("pass", 1))
+    check("floors pass", (p["floor_image-alt"]["verdict"], p["floor_label"]["verdict"]), ("pass", "pass"))
+    check("governance 5/5", p["governance_pair"]["d20_pair"], "5/5")
+
+    print("planted panel — fake-dirty (the unfavorable twin):")
+    p = rep1["panel"]["per_agent"]["fake-dirty"]
+    check("contrast bet refuted (1 -> 3)", p["contrast_bet"]["verdict"], "refuted")
+    check("kill fail", p["kill_criterion"]["verdict"], "fail")
+    check("image-alt floor regression (2 journeys)", p["floor_image-alt"]["verdict"], "regression")
+    check("governance 3/5 = regression", p["governance_pair"]["verdict"], "regression")
+
+    print("adjudication — the less favorable verdict leads:")
+    adj = rep1["panel"]["adjudication"]
+    check("contrast bet led by refuted", adj["contrast_bet"]["leads"], "refuted")
+    check("kill led by fail", adj["kill_criterion"]["leads"], "fail")
+    check("image-alt led by regression", adj["floor_image-alt"]["leads"], "regression")
+    check("both agents reported beside the lead",
+          sorted(adj["contrast_bet"]["per_agent"]), ["fake-clean", "fake-dirty"])
+
+    print("posture printed:")
+    check("descriptive posture in the report",
+          rep1["posture"].startswith("descriptive and estimation-oriented"), True)
+
+    print("self-test:", "PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--self-test", action="store_true")
+    a = ap.parse_args()
+    if a.self_test:
+        self_test()
+    main()

--- a/benchmark/round2/build_home.py
+++ b/benchmark/round2/build_home.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""
+build_home.py — build the sanitized per-agent HOME the protocol requires.
+
+PROTOCOL-DRAFT.md §Environment hygiene: "Dedicated sanitized HOME per agent —
+credentials and client configuration only; no user skills, no personal
+CLAUDE.md, no vault grants, no additionalDirectories. The profile's full
+contents are listed in the frozen snapshot."
+
+This script is the auditable answer to Round 1's leakage entry
+(study2/DEVIATIONS.md, 2026-08-29): the operator's live HOME carried a skill
+that named the standard in every system prompt and a permission grant
+pre-approving reads of the operator's vault. Round 2 agents get a HOME built
+from an explicit allow-list — nothing else — and the build emits a MANIFEST
+(path, size, sha256) that goes into the frozen snapshot verbatim.
+
+    python3 build_home.py --agent claude-code --dest ~/benchmark-homes/claude-code
+    python3 build_home.py --agent antigravity --dest ~/benchmark-homes/antigravity
+
+The manifest deliberately lists EVERY file in the built HOME, so any later
+addition is visible as a snapshot mismatch. Validation of sufficiency is the
+gate probe (`run.py --gate-probe`), not this script: if the client cannot
+authenticate from this HOME, extend the allow-list, rebuild, re-run the
+probe, and journal the change.
+
+Stdlib only.
+"""
+import argparse, hashlib, json, shutil, sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Closed allow-list: credentials and client configuration ONLY.
+# Sources are relative to the operator's real HOME; missing sources are
+# reported, not silently skipped.
+ALLOW = {
+    "claude-code": [
+        ".claude/.credentials.json",   # OAuth credentials
+    ],
+    # Round 1's Antigravity swap ran with an empty fresh HOME (ARM2.md /
+    # DEVIATIONS.md 2026-08-20) — authentication did not live in HOME. The
+    # empty list is therefore correct until the gate probe proves otherwise.
+    "antigravity": [],
+}
+
+# Written fresh into the sanitized HOME (never copied from the real one):
+# a minimal settings file with NO permission grants, NO additional
+# directories, NO hooks — so the leakage channel cannot re-enter by copy.
+CLAUDE_SETTINGS = {
+    "permissions": {"allow": [], "deny": []},
+}
+
+
+def sha256(p: Path) -> str:
+    h = hashlib.sha256()
+    with p.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agent", required=True, choices=sorted(ALLOW))
+    ap.add_argument("--dest", required=True, help="target HOME directory (must not exist)")
+    ap.add_argument("--source-home", default=str(Path.home()),
+                    help="operator HOME to copy credentials from")
+    args = ap.parse_args()
+
+    dest = Path(args.dest).expanduser().resolve()
+    src_home = Path(args.source_home).expanduser().resolve()
+    if dest.exists():
+        sys.exit(f"ABORT: {dest} already exists — a sanitized HOME is built once, "
+                 f"snapshotted, and never edited in place (rebuild under a new path).")
+    dest.mkdir(parents=True)
+
+    copied, missing = [], []
+    for rel in ALLOW[args.agent]:
+        src = src_home / rel
+        if not src.is_file():
+            missing.append(rel); continue
+        tgt = dest / rel
+        tgt.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(src, tgt)
+        copied.append(rel)
+
+    if args.agent == "claude-code":
+        s = dest / ".claude" / "settings.json"
+        s.parent.mkdir(parents=True, exist_ok=True)
+        s.write_text(json.dumps(CLAUDE_SETTINGS, indent=1) + "\n", encoding="utf-8")
+
+    manifest = {
+        "agent": args.agent,
+        "built_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "allow_list": ALLOW[args.agent],
+        "copied": copied,
+        "missing_sources": missing,
+        "files": [
+            {"path": str(p.relative_to(dest)), "bytes": p.stat().st_size,
+             "sha256": sha256(p)}
+            for p in sorted(dest.rglob("*")) if p.is_file()
+        ],
+    }
+    (dest / "MANIFEST.json").write_text(
+        json.dumps(manifest, indent=1, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    print(f"built {dest} for {args.agent}: {len(manifest['files'])} file(s)")
+    for f in manifest["files"]:
+        print(f"  {f['path']}  {f['bytes']}B  {f['sha256'][:16]}…")
+    if missing:
+        print(f"MISSING sources (extend or accept, then journal): {missing}")
+    print("Next: run the gate probe against this HOME before any retained run:\n"
+          f"  python3 run.py --agent {args.agent} --home {dest} --gate-probe")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark/round2/classifier_v2.py
+++ b/benchmark/round2/classifier_v2.py
@@ -1,0 +1,1330 @@
+#!/usr/bin/env python3
+"""Round 2 — consistency classifier, v2 (calibrated against Round 1's corpus,
+then adversarially verified and hardened before the freeze).
+
+Deterministic, DOM+local-JS static analysis, stdlib-only, condition-blind:
+the input is a directory of screen HTML files and nothing else — no run name,
+no condition label, no network. Same input → same output.
+
+v2 exists because calibrating v1 against Round 1's 30 real journeys exposed
+four instrument defects (spec: CLASSIFIER-v2.md), and an independent
+adversarial panel (three lenses — gaming, condition bias, regressions — with
+skeptic verification per finding) then confirmed 16 further defects in the
+first v2 draft. All are fixed or documented here; the spec carries the ledger.
+
+Core design (the four calibration cases):
+  A. tables   capability gate: sort signalling is compared only among tables
+              that are sortable; claiming aria-sort can only ADD a table to
+              the pool (anti-circularity).
+  B. cards    two lanes: static DOM (css-cover accepted, per-shape grouping)
+              + static JS-factory analysis (template/concat/builder styles,
+              receiver-bound per factory), per-SCREEN dominance, signatures
+              normalized to rendered shape (authoring style is metadata).
+  C. validity broken composite structure (required parent/children) excludes
+              the instance from variant comparison and is counted as an
+              exclusion; interactive elements carry their real implicit
+              roles; a composite with element content but no owned items is
+              broken too.
+  D. richness a sibling block beside the excess, never fused: the denominator
+              (families counted), instances, coverage, provenance — with
+              substance predicates so contentless stubs are reported apart.
+
+Partitioned comparison (like is compared with like):
+  nav    partitioned by slot: the primary nav (most links) across screens;
+         secondary navs (footer, breadcrumb) by accessible name.
+  toast  partitioned by announcement channel (polite vs assertive) — the
+         status/alert pair a standard may prescribe is purpose, not
+         dispersion; dispersion is measured within each channel.
+  table  structure dimension over all valid tables; state dimension over
+         capable tables only.
+
+The Node/TreeBuilder core is from study2/classifier.py v1 (frozen, sha256
+485d4064…) with two browser-faithfulness amendments measured to be
+judgment-neutral on the whole Round-1 corpus (duplicate attributes keep the
+FIRST value; <li>/<p>/<dt>/<dd>/<tr>/<td>/<th>/<option> auto-close their open
+sibling, per HTML5 optional end tags). v1 itself stays untouched and runs as
+a sensitivity analysis.
+
+  --self-test  validates every calibrated behavior against Round 1's
+               published screens (real fixtures) and the held-out synthetic
+               fixtures in fixtures/consistency/ — including counterfactuals
+               from the adversarial panel. A missing fixture directory is a
+               FAILURE, never a skip.
+"""
+import json
+import re
+import sys
+from pathlib import Path
+
+from html.parser import HTMLParser
+
+VOID = {"area","base","br","col","embed","hr","img","input","link","meta","source","track","wbr"}
+
+# HTML5 optional end tags: opening tag T auto-closes an open element whose
+# tag is in AUTOCLOSE[T]. Judgment-neutral on Round 1's corpus (measured);
+# fixes sibling card items written without </li> being parsed as nested.
+# The close walks UP through non-structural open elements (round-2 panel:
+# an unclosed <p> at the end of a <li> must not defeat the li-sibling
+# rule), stopping at any structural container so a nested list's items
+# stay inside it.
+AUTOCLOSE = {
+    "li": {"li"}, "p": {"p"}, "dt": {"dt", "dd"}, "dd": {"dt", "dd"},
+    "tr": {"tr"}, "td": {"td", "th"}, "th": {"td", "th"}, "option": {"option"},
+}
+STRUCTURAL = {"ul", "ol", "table", "thead", "tbody", "tfoot", "div", "section",
+              "article", "nav", "main", "header", "footer", "form", "dialog",
+              "select", "template", "body"}
+
+class Node:
+    __slots__ = ("tag","attrs","children","parent","text")
+    def __init__(self, tag, attrs, parent):
+        self.tag, self.parent = tag, parent
+        self.attrs = {}
+        for k, v in attrs:
+            k = k.lower()
+            if k not in self.attrs:      # browsers keep the FIRST duplicate
+                self.attrs[k] = v or ""
+        self.children, self.text = [], ""
+    def get(self, k, d=""): return self.attrs.get(k, d)
+    def walk(self):
+        yield self
+        for c in self.children: yield from c.walk()
+    def find_all(self, pred): return [n for n in self.walk() if pred(n)]
+    def role(self): return self.get("role").strip().lower()
+
+class TreeBuilder(HTMLParser):
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.root = Node("#root", [], None); self.cur = self.root
+    def handle_starttag(self, tag, attrs):
+        close = AUTOCLOSE.get(tag)
+        if close:
+            n = self.cur
+            while n is not self.root and n.tag not in STRUCTURAL:
+                if n.tag in close:
+                    self.cur = n.parent
+                    break
+                n = n.parent
+        n = Node(tag, attrs, self.cur); self.cur.children.append(n)
+        if tag not in VOID: self.cur = n
+    def handle_startendtag(self, tag, attrs):
+        self.cur.children.append(Node(tag, attrs, self.cur))
+    def handle_endtag(self, tag):
+        n = self.cur
+        while n is not self.root and n.tag != tag: n = n.parent
+        if n is not self.root: self.cur = n.parent
+    def handle_data(self, data):
+        self.cur.text += data
+
+def parse(path: Path) -> Node:
+    tb = TreeBuilder(); tb.feed(path.read_text(errors="replace")); return tb.root
+
+def _ancestors(n: Node):
+    p = n.parent
+    while p is not None: yield p; p = p.parent
+
+def _desc(n: Node):
+    for c in n.children:
+        yield c; yield from _desc(c)
+
+# ---- signature helpers (categories recorded, never judged) — from v1 ----
+
+def naming_of(n: Node, doc: Node) -> str:
+    if n.get("aria-labelledby"): return "aria-labelledby"
+    if n.get("aria-label"): return "aria-label"
+    return "none"
+
+def field_naming(form: Node, doc: Node) -> str:
+    """Dominant naming mechanism across the form's fields."""
+    ids = {n.get("for") for n in doc.find_all(lambda x: x.tag == "label")}
+    votes = []
+    for f in form.find_all(lambda x: x.tag in ("input","select","textarea") and x.get("type") != "hidden"):
+        if f.get("id") and f.get("id") in ids: votes.append("label-for")
+        elif any(a.tag == "label" for a in _ancestors(f)): votes.append("label-wrap")
+        elif f.get("aria-label") or f.get("aria-labelledby"): votes.append("aria")
+        elif f.get("placeholder"): votes.append("placeholder-only")
+        else: votes.append("none")
+    if not votes: return "no-fields"
+    return max(sorted(set(votes)), key=votes.count)
+
+# =====================================================================
+# Case C — structural validity gate (exclusion, never variant-counting)
+# =====================================================================
+# Scope is deliberately narrow (it does not duplicate axe): required
+# children/parents of ARIA composite containers plus the native content
+# model of ul/ol/dl/table — the minimum needed to decide "does this
+# instance enter the comparison". Empty containers are vacuously valid
+# (client-side population is not static evidence of a broken ladder), but a
+# composite with element content and NO owned item anywhere is broken (an
+# AT user gets an announced menu/tablist with zero entries). Hidden
+# subtrees ARE checked: the calibration's target case is a closed dropdown
+# (ul[role=menu][hidden]) whose broken ladder a rendered-DOM scan would
+# only see with the menu open.
+
+SKIP_TAGS = {"script", "template", "style"}
+
+ALLOWED = {
+    "menu":       {"menuitem", "menuitemcheckbox", "menuitemradio", "separator", "group"},
+    "menubar":    {"menuitem", "menuitemcheckbox", "menuitemradio", "separator", "group"},
+    "listbox":    {"option", "group"},
+    "tablist":    {"tab"},
+    "radiogroup": {"radio"},
+    "tree":       {"treeitem", "group"},
+    "table":      {"row", "rowgroup", "caption"},
+    "grid":       {"row", "rowgroup", "caption"},
+    "rowgroup":   {"row"},
+    "row":        {"cell", "gridcell", "columnheader", "rowheader"},
+    "list":       {"listitem"},
+}
+
+IMPLICIT = {
+    "li": "listitem", "tr": "row", "td": "cell", "th": "columnheader",
+    "option": "option", "ul": "list", "ol": "list",
+    "thead": "rowgroup", "tbody": "rowgroup", "tfoot": "rowgroup",
+    "caption": "caption",
+    # Adversarial-panel amendment: interactive/semantic elements carry their
+    # real implicit roles, so a div[role=menu] full of plain links/buttons is
+    # a broken composite, exactly like ul[role=menu] > li. Only genuinely
+    # role-less tags (div, span, p, legend, label, …) stay generic and
+    # therefore transparent.
+    "button": "button", "summary": "button", "select": "listbox",
+    "textarea": "textbox", "table": "table", "nav": "navigation",
+    "form": "form", "dialog": "dialog", "hr": "separator",
+    "h1": "heading", "h2": "heading", "h3": "heading",
+    "h4": "heading", "h5": "heading", "h6": "heading",
+}
+
+HTML_KIDS = {
+    "ul": {"li"}, "ol": {"li"},
+    "dl": {"dt", "dd", "div"},
+    "table": {"caption", "colgroup", "thead", "tbody", "tfoot", "tr"},
+    "thead": {"tr"}, "tbody": {"tr"}, "tfoot": {"tr"}, "tr": {"td", "th"},
+}
+
+def resolved_role(n: Node) -> str:
+    r = n.role()
+    if r: return r
+    if n.tag == "a":
+        return "link" if n.get("href") else "generic"
+    if n.tag == "img":
+        return "presentation" if n.get("alt", None) == "" else "img"
+    if n.tag == "input":
+        t = n.get("type", "text").lower()
+        if t == "radio": return "radio"
+        if t == "checkbox": return "checkbox"
+        if t == "hidden": return "generic"
+        return "textbox"
+    return IMPLICIT.get(n.tag, "generic")
+
+def check_composite(container: Node, expect_key: str, errors: list) -> int:
+    """Direct element children must resolve into ALLOWED[expect_key].
+    role=none/presentation delegates down (the correct APG ladder rung);
+    GENERIC elements are transparent (ARIA 1.2 allows generics as
+    intermediate structural descendants — a radiogroup's legend/hint/div
+    wrappers are fine, while li inside role=menu errors because its
+    implicit role is listitem, and a[href]/button error because their
+    implicit roles are link/button — panel amendment); group is
+    transparent for the same expectation; rowgroup/row descend into their
+    own models. Returns the count of owned items found (for the
+    content-but-no-items check). No children ⇒ vacuously valid."""
+    allowed = ALLOWED[expect_key]
+    found = 0
+    for k in container.children:
+        if k.tag in SKIP_TAGS: continue
+        r = resolved_role(k)
+        if r in ("presentation", "none", "generic"):
+            found += check_composite(k, expect_key, errors)
+        elif r in allowed:
+            found += 1
+            if r == "group":
+                found += check_composite(k, expect_key, errors)
+            elif r == "rowgroup":
+                check_composite(k, "rowgroup", errors)
+            elif r == "row":
+                check_composite(k, "row", errors)
+        else:
+            errors.append(f"<{k.tag} role={k.role() or '(implicit)' + r}> child of "
+                          f"<{container.tag}> expecting {sorted(allowed)}")
+    return found
+
+def html_check(container: Node, errors: list):
+    ok = HTML_KIDS[container.tag]
+    for k in container.children:
+        if k.tag in SKIP_TAGS: continue
+        if k.tag not in ok:
+            errors.append(f"<{k.tag}> child of <{container.tag}> (HTML content model)")
+
+def instance_errors(anchor: Node) -> list:
+    """Local validity of one family instance: walk its subtree, check every
+    composite-role container and every native list/table container found.
+    Documented scope limit: a native container carrying a NON-composite role
+    (e.g. ul[role=navigation]) is checked by neither path — mirroring axe,
+    whose list rule also stands down when the role is overridden."""
+    errors = []
+    for n in anchor.walk():
+        r = n.role()
+        if r in ALLOWED:
+            elems = [k for k in n.children if k.tag not in SKIP_TAGS]
+            found = check_composite(n, r, errors)
+            if elems and not found and not errors:
+                errors.append(f"<{n.tag} role={r}> has element content but no "
+                              f"owned {sorted(ALLOWED[r])} anywhere (announced "
+                              f"composite with zero items)")
+        elif not r and n.tag in HTML_KIDS:
+            html_check(n, errors)
+    return errors
+
+# =====================================================================
+# Case A — tables: capability gate before state comparison
+# =====================================================================
+# Structure dimension: (container, heads) over ALL valid tables.
+# State dimension: sort signalling compared ONLY among tables that are
+# sortable. Capability is judged primarily WITHOUT aria-sort: interactive
+# descendant in a column-header cell, or handler/focus affordance anywhere
+# in the header cell's subtree. The claim term (aria-sort present) can only
+# ADD a table to the compared pool, never remove one — a run cannot exit
+# the comparison by deleting its own honest markup (anti-circularity).
+# Signal scope is the whole header-cell subtree: aria-sort placed on the
+# button inside the th (invalid placement, real signal) still counts, and
+# presence is what counts, not value (aria-sort="none" means "sortable,
+# not sorted now"; a bare valueless aria-sort attribute also counts).
+
+def _has_aria_sort(n: Node) -> bool:
+    return "aria-sort" in n.attrs
+
+def _first_row(table: Node):
+    for n in table.walk():
+        if n is not table and n.tag == "tr":
+            return n
+    return None
+
+def col_header_cells(table: Node):
+    """Column header cells: th (thead ancestor, scope=col ASCII
+    case-insensitive, or sitting in the table's FIRST row without
+    scope=row — bare-th markup heads columns by HTML convention, so the
+    gate does not depend on the thead/scope idiom), and any element with
+    role=columnheader — so ARIA grids (div[role=grid]) get the same gate
+    and the same anti-circularity term as native tables (both panel
+    rounds)."""
+    out = []
+    first = _first_row(table)
+    for th in table.find_all(lambda x: x.tag == "th"):
+        scope = th.get("scope").strip().lower()
+        if (any(a.tag == "thead" for a in _ancestors(th))
+                or scope == "col"
+                or (first is not None and th.parent is first and scope != "row")):
+            out.append(th)
+    for ch in table.find_all(lambda x: x.tag != "th" and x.role() == "columnheader"):
+        out.append(ch)
+    return out
+
+def table_sortable(table: Node):
+    """(capable, evidence). Known blind spot, documented in the spec:
+    JS-attached listeners with no DOM footprint (addEventListener on plain
+    th) are invisible — those tables stay out of the state pool unless
+    they claim aria-sort."""
+    ths = col_header_cells(table)
+    for th in ths:
+        if [n for n in th.walk() if n is not th and
+                (n.tag == "button" or n.role() == "button"
+                 or (n.tag == "a" and n.get("href")))]:
+            return True, "interactive-descendant-in-header"
+        for n in th.walk():   # handler/focus affordance anywhere in the cell
+            # round-2 amendment: a form control in the header (select-all
+            # checkbox, filter input) is a selection/filter affordance,
+            # not a sort affordance — its handlers do not open the gate
+            if resolved_role(n) in ("checkbox", "radio", "textbox", "listbox"):
+                continue
+            if n.get("onclick") or n.get("onkeydown") or n.get("onkeypress"):
+                return True, "handler-in-header"
+            if n.role() == "button":
+                return True, "role-button-in-header"
+            ti = n.get("tabindex")
+            if ti and not ti.strip().startswith("-"):
+                return True, "focusable-header"
+    if any(_has_aria_sort(th) for th in ths):
+        return True, "aria-sort-claim-only"
+    return False, "static"
+
+def table_sort_signal(table: Node) -> str:
+    for th in col_header_cells(table):
+        if any(_has_aria_sort(n) for n in th.walk()):
+            return "aria-sort"
+    return "none"
+
+def tables(doc: Node):
+    out = []
+    for n in doc.find_all(lambda x: x.tag == "table" or x.role() in ("table","grid")):
+        ths = n.find_all(lambda x: x.tag == "th" or x.role() == "columnheader")
+        heads = ("th-scope" if any(t.get("scope") for t in ths) else "th") if ths else "none"
+        container = "table-element" if n.tag == "table" else f"role-{n.role()}"
+        capable, evidence = table_sortable(n)
+        out.append(("table", (container, heads), n,
+                    {"sort_capable": capable, "sort_evidence": evidence,
+                     "sort_signal": table_sort_signal(n)}))
+    return out
+
+# =====================================================================
+# Families carried from v1, with panel-driven partitioning
+# =====================================================================
+
+def dialogs(doc: Node):
+    out = []
+    for n in doc.find_all(lambda x: x.tag == "dialog" or x.role() in ("dialog","alertdialog")):
+        container = "dialog-element" if n.tag == "dialog" else f"role-{n.role()}"
+        out.append(("dialog", (container,
+                    "modal" if (n.tag=="dialog" or n.get("aria-modal")=="true") else "non-modal",
+                    naming_of(n, doc)), n, None))
+    return out
+
+def navs(doc: Node):
+    """Panel amendments, both rounds (like-with-like): navs are PARTITIONED
+    before variant comparison, and identity comes from the nav's own
+    accessible name — a NAMED nav is never promoted to some other slot, so
+    a footer nav on a footer-only screen, or a breadcrumb on a screen whose
+    main nav is client-rendered, stays in its own pool instead of being
+    charged against the main nav (two confirmed round-2 findings). Pools:
+    `label:<normalized accessible name>` for named navs; the link-richest
+    UNNAMED nav of a screen is `unnamed-main` (DOM order breaks ties);
+    remaining unnamed navs share `unnamed-other`. The dropdown axis records
+    the SET of mechanisms present."""
+    cands = doc.find_all(lambda x: x.tag == "nav")
+    if not cands:  # pilot lesson (v1): div-built headers — outermost cluster of >=3 internal links
+        raw = [n for n in doc.find_all(lambda x: x.tag in ("header","div","ul"))
+               if len([a for a in n.find_all(lambda a: a.tag == "a")
+                       if ".html" in a.get("href","") or a.get("href","").startswith("#") is False]) >= 3]
+        cands = [n for n in raw if not any(p in raw for p in _ancestors(n))][:1]
+    if not cands: return []
+    def links(n): return len([a for a in n.find_all(lambda a: a.tag == "a") if a.get("href")])
+    unnamed = [n for n in cands
+               if not (n.get("aria-label") or n.get("aria-labelledby")).strip()]
+    unnamed_main = max(unnamed, key=links) if unnamed else None
+    out = []
+    for n in cands:
+        mechs = sorted({("details" if x.tag == "details" else "aria-expanded")
+                        for x in n.find_all(lambda x: x.get("aria-expanded") != "" or x.tag == "details")})
+        drop = "+".join(mechs) if mechs else "static-or-css"
+        label = (n.get("aria-label") or n.get("aria-labelledby")).strip().lower()
+        if label:
+            slot = f"label:{label}"
+        elif n is unnamed_main:
+            slot = "unnamed-main"
+        else:
+            slot = "unnamed-other"
+        out.append(("nav", (f"{n.tag}-element", drop, naming_of(n, doc)), n,
+                    {"partition": slot}))
+    return out
+
+def forms(doc: Node):
+    out = []
+    cands = doc.find_all(lambda x: x.tag == "form")
+    if not cands:
+        cands = [d for d in doc.find_all(lambda x: x.tag in ("div","section"))
+                 if len([i for i in d.children if i.tag in ("input","select","textarea","label")]) >= 3]
+    for n in cands:
+        live = n.find_all(lambda x: x.role() in ("alert","status") or x.get("aria-live"))
+        invalid = n.find_all(lambda x: x.get("aria-invalid") != "")
+        err = "live-region" if live else ("aria-invalid" if invalid else "none-visible")
+        out.append(("form", (f"{n.tag}-element", field_naming(n, doc), err), n, None))
+    return out
+
+def toasts(doc: Node):
+    """Panel amendment: announcement severity is PURPOSE, not convention —
+    a run using role=status for success and role=alert for errors (the
+    pair a standard may prescribe) is not dispersing. Instances are
+    partitioned by channel (polite vs assertive) and dispersion is
+    measured within each channel (role=status vs aria-live=polite IS
+    dispersion — two conventions for the same channel).
+    Second-round amendment: a live-region WRAPPER around a live-region
+    toast is one widget, not two conventions (the belt-and-suspenders
+    idiom a real D run was charged +1 for) — when a matched element
+    contains a matched descendant, only the innermost is an instance;
+    aria-live values compare case-insensitively (HTML enumerated
+    attributes)."""
+    matched = doc.find_all(lambda x: x.role() in ("status","alert") or x.get("aria-live"))
+    matched_ids = {id(n) for n in matched}
+    out = []
+    for n in matched:
+        if any(id(d) in matched_ids for d in _desc(n)):
+            continue   # wrapper around an inner live region: one widget
+        live = n.get("aria-live").strip().lower()
+        mech = f"role-{n.role()}" if n.role() else f"aria-live-{live}"
+        channel = ("polite" if n.role() == "status" or live == "polite"
+                   else "assertive" if n.role() == "alert" or live == "assertive"
+                   else "other")
+        out.append(("toast", (n.tag, mech), n, {"partition": channel}))
+    return out
+
+# =====================================================================
+# Case B — cards: DOM lane + receiver-bound JS-factory lane
+# =====================================================================
+
+COVER_RE = re.compile(r'(?:^|[\s_-])(cover|thumb|capa)\b|__cover|cover__|book-cover', re.I)
+
+def imageish(k: Node):
+    """Ranked (round-2 amendment): a real cover (img/picture/css-cover)
+    outranks an svg, and a decorative aria-hidden svg never defines the
+    card's image class — a wishlist-star badge must not split an
+    otherwise uniform grid into two conventions."""
+    best = None
+    RANK = {"img": 0, "picture": 1, "css-cover": 2, "svg": 3}
+    def consider(label):
+        nonlocal best
+        if best is None or RANK[label] < RANK[best]: best = label
+    for d in _desc(k):
+        if d.tag == "img": consider("img")
+        elif d.tag == "picture": consider("picture")
+        elif d.tag == "svg" and d.get("aria-hidden").strip().lower() != "true":
+            consider("svg")
+        elif d.tag in ("div","span","i") and COVER_RE.search(d.get("class","")):
+            consider("css-cover")
+    return best
+
+def actionish(k: Node):
+    if any(d.tag == "button" for d in _desc(k)): return "button"
+    if k.tag == "a" and k.get("href"): return "link-wrapper"
+    if any(d.tag == "a" and d.get("href") for d in _desc(k)): return "link"
+    return None
+
+def card_shape(k: Node):
+    img, act = imageish(k), actionish(k)
+    return (img, act) if img and act else None
+
+def item_shape(k: Node) -> str:
+    inner = next((d for d in _desc(k) if d.tag == "article"), None)
+    return f"{k.tag}>article" if (inner and k.tag != "article") else k.tag
+
+def _has_substance(k: Node) -> bool:
+    """A card item with no text anywhere and no real image source is a stub."""
+    if any((d.text or "").strip() for d in [k] + list(_desc(k))): return True
+    return any(d.tag == "img" and d.get("src") for d in _desc(k))
+
+def cards_dom(doc: Node):
+    """DOM lane: sibling repetition (>=3) of card-shaped items grouped by
+    (tag, first class token) and THEN by full shape — two conventions
+    sharing one grid are two variants (panel amendment). Innermost
+    qualifying container wins; inert <template> subtrees are skipped."""
+    out = []
+    def visit(n):
+        if n.tag == "template": return False
+        below = any([visit(c) for c in n.children])
+        if n.tag not in ("ul","ol","div","section") or below: return below
+        groups = {}
+        for c in n.children:
+            if c.tag in ("li","article","div","a"):
+                key = (c.tag, (c.get("class","").split() or [""])[0])
+                groups.setdefault(key, []).append(c)
+        hit = False
+        for grp in groups.values():
+            by_shape = {}
+            for k in grp:
+                s = card_shape(k)
+                if s: by_shape.setdefault((item_shape(k),) + s, []).append(k)
+            for shape, ks in by_shape.items():
+                if len(ks) >= 3:
+                    substantive = any(_has_substance(k) for k in ks)
+                    out.append(((f"{n.tag}-grid",) + shape, n, substantive))
+                    hit = True
+        return hit or below
+    visit(doc)
+    return out
+
+# --- JS lane (precedent: v1's script_dialogs static scan) ---
+
+LIT_RE = re.compile(r"`((?:\\.|[^`\\])*)`|'((?:\\.|[^'\\])*)'|\"((?:\\.|[^\"\\])*)\"", re.S)
+MK_RE = re.compile(r"\b[A-Za-z_$][\w$.]*\(\s*['\"](article|li|img|svg|button|a|div|span|h[1-6]|p)['\"]\s*[,)]")
+ITER_RE = re.compile(r"\.forEach\(|\.map\(|\bfor\s*\(|\bwhile\s*\(")
+INTERP_COVER_RE = re.compile(r"\$\{[^}]*(cover|svg|img|thumb|capa)[^}]*\}", re.I)
+MAX_FACTORY_UNIT = 6000   # a >6KB "unit" is an IIFE aggregating a whole file, not a card factory
+
+REGEX_PRECEDERS = set("=(,:[!&|?{;+-*%<>^~")
+
+def _js_scan(src: str, keep_plain_strings: bool, collect):
+    """One shared JS lexer (panel round 2): walks src tracking template
+    literals WITH their ${…} interpolations (interpolation code is real
+    code — strings/templates/regexes inside it are handled recursively via
+    a mode stack), plain strings, comments, and regex literals (a '/'
+    whose previous expression cannot continue starts a regex — the
+    heuristic that fixed the real .replace(/"/g,…) misread). `collect`
+    receives every literal TEXT body (plain strings and template text
+    chunks, in source order, inner templates included) so fragment
+    parsing sees nested card templates. Returns the blanked text:
+    literal bodies/comments/regex bodies spaced out, interpolation code
+    kept; with keep_plain_strings, '…'/"…" bodies survive for the
+    binding scans. Documented limit: '}' after a block is read as a
+    possible division, never a regex start."""
+    out = list(src)
+    i, n = 0, len(src)
+    prev = ""
+    stack = []          # "tpl" entries: inside a template literal's text
+    depth = []          # brace depth per open interpolation
+    KEYWORDS = ("return", "typeof", "case", "in", "of", "new", "delete", "void", "do", "else")
+    def regex_position():
+        if not prev: return True
+        if prev in REGEX_PRECEDERS: return True
+        tail = src[max(0, i-8):i].rstrip()
+        return any(tail.endswith(k) and (len(tail) == len(k) or not tail[-len(k)-1].isalnum())
+                   for k in KEYWORDS)
+    while i < n:
+        c = src[i]
+        in_tpl = bool(stack) and stack[-1] == "tpl"
+        if in_tpl:
+            if c == "\\":
+                out[i] = " "
+                if i + 1 < n: out[i+1] = " "
+                i += 2; continue
+            if c == "`":
+                stack.pop(); prev = "`"; i += 1; continue
+            if c == "$" and i + 1 < n and src[i+1] == "{":
+                stack.append("interp"); depth.append(0)
+                collect("${")           # interpolation text stays visible to
+                prev = ""; i += 2; continue   # the fragment parser (${coverMarkup})
+            collect(c)
+            out[i] = " "
+            i += 1; continue
+        # code mode (top level or inside an interpolation)
+        if c == "`":
+            stack.append("tpl"); i += 1; continue
+        if stack and stack[-1] == "interp":
+            if c == "{": depth[-1] += 1
+            elif c == "}":
+                if depth[-1] == 0:
+                    stack.pop(); depth.pop()
+                    collect("}")
+                    i += 1; continue
+                depth[-1] -= 1
+        if c in "'\"":
+            q = c; j = i + 1
+            body = []
+            while j < n:
+                if src[j] == "\\": body.append(src[j:j+2]); j += 2; continue
+                if src[j] == q: break
+                body.append(src[j]); j += 1
+            collect("".join(body))
+            if not keep_plain_strings:
+                for k in range(i + 1, min(j, n)): out[k] = " "
+            prev = q; i = j + 1; continue
+        if c == "/" and i + 1 < n and src[i+1] == "/":
+            j = src.find("\n", i)
+            j = n if j < 0 else j
+            for k in range(i, j): out[k] = " "
+            i = j; continue
+        if c == "/" and i + 1 < n and src[i+1] == "*":
+            j = src.find("*/", i + 2)
+            j = n if j < 0 else j + 2
+            for k in range(i, min(j, n)): out[k] = " "
+            i = j; continue
+        if c == "/" and regex_position():
+            j, in_class = i + 1, False
+            while j < n:
+                d = src[j]
+                if d == "\\": j += 2; continue
+                if d == "\n": break
+                if in_class:
+                    if d == "]": in_class = False
+                elif d == "[": in_class = True
+                elif d == "/": break
+                j += 1
+            if j < n and src[j] == "/":
+                for k in range(i + 1, j): out[k] = " "
+                while j + 1 < n and src[j+1].isalpha(): j += 1
+                prev = "/"; i = j + 1; continue
+            prev = c; i += 1; continue
+        if "interp" in stack: collect(c)   # interpolation code is template text too
+        if not c.isspace(): prev = c
+        i += 1
+    return "".join(out)
+
+def blank_code(src: str, keep_plain_strings: bool = False) -> str:
+    return _js_scan(src, keep_plain_strings, lambda _: None)
+
+def literals(src: str) -> str:
+    """All literal text bodies in source order — plain strings and template
+    TEXT chunks, nested templates included (the second panel round's
+    nested-map catalog idiom lives one interpolation deep)."""
+    parts = []
+    _js_scan(src, True, parts.append)
+    return "".join(parts)
+
+def units_of(src: str, blanked: str):
+    """(start, body) for each brace-matched function body, smallest first —
+    smallest-first means a card factory inside a big IIFE is still found.
+    Matching runs on the BLANKED text (braces in strings/comments ignored);
+    the returned body is the ORIGINAL text at the same offsets."""
+    out = []
+    for m in re.finditer(r"\bfunction\b[^{]*|=>\s*", blanked):
+        i = blanked.find("{", m.end()-1)
+        if i < 0 or i - m.end() > 3: continue
+        depth, j = 0, i
+        while j < len(blanked):
+            if blanked[j] == "{": depth += 1
+            elif blanked[j] == "}":
+                depth -= 1
+                if depth == 0: break
+            j += 1
+        out.append((m.start(), src[i:j+1]))
+    return sorted(out, key=lambda t: len(t[1]))
+
+def _frag_imageish(n: Node):
+    img = imageish(n)
+    if img: return img
+    for d in [n] + list(_desc(n)):
+        # interpolated image markup normalizes to the plain image class —
+        # authoring style must not create a variant (panel amendment)
+        if INTERP_COVER_RE.search(d.text or ""): return "img"
+    return None
+
+def fragment_card(frag_src: str):
+    """Parse the unit's concatenated string literals as HTML; look for a
+    card-shaped element. Fragment forests (wrapper element created via
+    createElement outside the template) yield shape=None — indeterminate,
+    excluded from variant identity but still an instance."""
+    if "<" not in frag_src: return None
+    tb = TreeBuilder(); tb.feed(frag_src)
+    for n in tb.root.walk():
+        if n.tag in ("li","article","div","a","section"):
+            img, act = _frag_imageish(n), actionish(n)
+            if img and act: return (item_shape(n), img, act)
+    img, act = _frag_imageish(tb.root), actionish(tb.root)
+    if img and act and any(c.tag for c in tb.root.children):
+        return (None, img, act)
+    return None
+
+def _name_before(src: str, start: int):
+    """Factory/helper name from the text before a function unit: covers
+    `function NAME(`, `ui.NAME = function`, `NAME: function`, and
+    arrow assignments `const NAME = (a) =>` / `NAME = a =>` (panel
+    amendment — arrow factories were nameless before)."""
+    m2 = re.match(r"\s*function\s+([\w$]+)", src[start:start+60])
+    if m2: return m2.group(1)
+    head = src[max(0, start-100):start].rstrip()
+    m = re.search(r"[.\s]([\w$]+)\s*[:=]$", head)
+    if m: return m.group(1)
+    m = re.search(r"(?:const|let|var)?\s*[\w$.]*?([\w$]+)\s*=\s*(?:async\s*)?(?:\([^)]*\)|[\w$]+)\s*$", head)
+    if m: return m.group(1)
+    return None
+
+def factories(src: str, blanked_full: str):
+    """[(name_or_None, unit_src, sig, start, style)] — card factories in one
+    script. sig = (shape_or_None, image, action); authoring style
+    (template vs builder) is metadata, never variant identity (panel
+    amendment)."""
+    found = []
+    for start, unit in units_of(src, blanked_full):
+        if len(unit) > MAX_FACTORY_UNIT: continue
+        sig, style = fragment_card(literals(unit)), "template"
+        if not sig:
+            tags = set(MK_RE.findall(unit))   # builder style: el('article', …)
+            if "img" in tags and ({"button","a"} & tags) and ({"article","li","div"} & tags):
+                root = "article" if "article" in tags else ("li" if "li" in tags else "div")
+                sig, style = (root, "img", "button" if "button" in tags else "link"), "builder"
+        if sig:
+            found.append((_name_before(src, start), unit, sig, start, style))
+    seen, out = set(), []
+    for name, unit, sig, start, style in found:
+        if sig not in seen: seen.add(sig); out.append((name, unit, sig, start, style))
+    return out
+
+def bindings(src_binding: str) -> dict:
+    """var -> host key, over the binding-blanked text (template literals and
+    comments removed; plain quotes kept — the ids live inside them).
+    Host keys: ('id', x) from getElementById/'#x' selectors, ('attr', name)
+    from querySelector('[data-…]') attribute selectors, ('class', name)
+    from querySelector('.class') (round-2 amendment)."""
+    b = {}
+    for m in re.finditer(r"\b([\w$]+)\s*=\s*[^;\n]{0,80}?(?:getElementById\(\s*['\"]|querySelector\(\s*['\"]#|qs\(\s*['\"]#)([\w-]+)", src_binding):
+        b[m.group(1)] = ("id", m.group(2))
+    for m in re.finditer(r"\b([\w$]+)\s*=\s*[^;\n]{0,80}?querySelector\(\s*['\"]\[([\w-]+)[^\]]*\]", src_binding):
+        b[m.group(1)] = ("attr", m.group(2))
+    for m in re.finditer(r"\b([\w$]+)\s*=\s*[^;\n]{0,80}?querySelector\(\s*['\"]\.([\w-]+)", src_binding):
+        b[m.group(1)] = ("class", m.group(2))
+    return b
+
+# A render statement referencing the factory: NAME( call, bare NAME as a
+# callback (.map(NAME), .forEach(NAME)), or ns.NAME — round-2 amendment.
+def _use_re(name):
+    return r"(?:[\w$]+\.)?" + re.escape(name) + r"\b"
+
+def _chained_keys(src_b, name):
+    """Receivers used inline with no variable: document.getElementById('x')
+    .innerHTML = …NAME…  (round-2 amendment)."""
+    keys = set()
+    pat = (r"getElementById\(\s*['\"]([\w-]+)['\"]\s*\)\s*\.\s*"
+           r"(?:innerHTML\s*[+]?=|appendChild\(|append\(|prepend\(|insertAdjacentHTML\()"
+           r"[^;]{0,300}?" + _use_re(name))
+    for m in re.finditer(pat, src_b, re.S):
+        keys.add(("id", m.group(1)))
+    pat2 = (r"querySelector\(\s*['\"]#([\w-]+)['\"]\s*\)\s*\.\s*"
+            r"(?:innerHTML\s*[+]?=|appendChild\(|append\(|prepend\(|insertAdjacentHTML\()"
+            r"[^;]{0,300}?" + _use_re(name))
+    for m in re.finditer(pat2, src_b, re.S):
+        keys.add(("id", m.group(1)))
+    return keys
+
+def render_helpers(src: str, factory_name: str) -> set:
+    """Depth-2 indirection for ONE factory: names of functions that take a
+    container parameter and append/insert that factory's output
+    (ui.renderGrid(container, …)). The factory-use gate accepts calls AND
+    bare callback references (.map(bookCard)) — round-2 amendment."""
+    helpers = set()
+    blanked_full = blank_code(src)
+    for start, unit in units_of(src, blanked_full):
+        if len(unit) > MAX_FACTORY_UNIT: continue
+        unit_b = blank_code(unit, keep_plain_strings=True)
+        if not re.search(_use_re(factory_name), unit_b): continue
+        if re.search(r"[\w$]+\.(?:appendChild|append|prepend|insertAdjacentHTML)\(|[\w$]+\.innerHTML\s*[+]?=", unit_b):
+            name = _name_before(src, start)
+            if name and name != factory_name: helpers.add(name)
+    return helpers
+
+def receiver_keys_for(all_scripts, name, unit, start, own_idx, name_owners):
+    """Host keys of elements that receive THIS factory's output (both panel
+    rounds: resolution is per factory, and name-based resolution in a
+    FOREIGN script is only trusted when that script does not define its own
+    factory of the same name — a dead same-name factory elsewhere must not
+    borrow this one's render sites). Paths in: named factory at a render
+    site (incl. bare-callback .map(name) and ns.name forms); chained
+    no-variable receivers; anonymous factory with a receiver inside/just
+    before its unit; depth-2 helper called with a bound container."""
+    keys = set()
+    helper_names = set()
+    if name:
+        for idx, (_, src, _sb) in enumerate(all_scripts):
+            if idx != own_idx and idx in name_owners.get(name, set()): continue
+            helper_names |= render_helpers(src, name)
+    for idx, (_, src, src_b) in enumerate(all_scripts):
+        binds = bindings(src_b)
+        if name and (idx == own_idx or idx not in name_owners.get(name, set())):
+            for m in re.finditer(r"([\w$]+)\.(?:appendChild|append|prepend)\(\s*(?:\.\.\.)?[^)]{0,200}?" + _use_re(name), src_b):
+                if m.group(1) in binds: keys.add(binds[m.group(1)])
+            for m in re.finditer(r"([\w$]+)\.(?:innerHTML\s*[+]?=|insertAdjacentHTML\()[^;]{0,300}?" + _use_re(name), src_b, re.S):
+                if m.group(1) in binds: keys.add(binds[m.group(1)])
+            keys |= _chained_keys(src_b, name)
+            for helper in helper_names:
+                for m in re.finditer(r"(?:[\w$]+\.)?" + re.escape(helper) + r"\s*\(\s*([\w$]+)", src_b):
+                    if m.group(1) in binds: keys.add(binds[m.group(1)])
+        if unit in src:
+            u_start = src.find(unit)
+            unit_b = blank_code(unit, keep_plain_strings=True)
+            zones = [unit_b, src_b[max(0, u_start-250):u_start]]
+            for zone in zones:
+                for m in re.finditer(r"([\w$]+)\.(?:appendChild|append|prepend|insertAdjacentHTML)\(|([\w$]+)\.innerHTML\s*[+]?=", zone):
+                    r = m.group(1) or m.group(2)
+                    if r in binds: keys.add(binds[r])
+    return keys
+
+def script_sources(screen: Path, doc: Node):
+    out, base = [], screen.parent.resolve()
+    for s in doc.find_all(lambda x: x.tag == "script"):
+        if s.get("src"):
+            js = (base / s.get("src")).resolve()
+            if js.is_file() and base in js.parents:
+                src = js.read_text(errors="replace")
+                out.append((js.name, src, blank_code(src, keep_plain_strings=True)))
+        elif s.text.strip():
+            out.append(("<inline>", s.text, blank_code(s.text, keep_plain_strings=True)))
+    return out
+
+def _host_matches(el: Node, keys: set) -> bool:
+    for kind, val in keys:
+        if kind == "id" and el.get("id") == val: return True
+        if kind == "attr" and val in el.attrs: return True
+        if kind == "class" and val in el.get("class", "").split(): return True
+    return False
+
+PLACEHOLDER_RE = re.compile(r"loading|empty|placeholder|skeleton|spinner|carregando", re.I)
+
+def _near_empty(el: Node) -> bool:
+    """A grid host waiting for JS: no element children, or only noscript /
+    loading-placeholder children (round-2 amendment — a skeleton item or a
+    noscript fallback must not disqualify the real host)."""
+    real = [c for c in el.children if c.tag
+            and c.tag != "noscript"
+            and not PLACEHOLDER_RE.search(c.get("class", ""))
+            and not PLACEHOLDER_RE.search(c.get("id", ""))]
+    return len(real) <= 1
+
+def cards_js(screen: Path, doc: Node):
+    """JS lane: a factory's signature counts for this screen iff the DOM
+    holds a bound, (near-)empty grid container that receives THAT factory's
+    output. The container axis comes from the receiving host element, so
+    DOM-lane and JS-lane signatures share one vocabulary. Top-level render
+    code with no enclosing function is scanned as one pseudo-unit."""
+    scripts = script_sources(screen, doc)
+    facs = []
+    name_owners = {}
+    for idx, (_, src, _sb) in enumerate(scripts):
+        blanked = blank_code(src)
+        if not ITER_RE.search(blanked): continue   # repetition proxy
+        found = factories(src, blanked)
+        if not found and len(src) <= MAX_FACTORY_UNIT:
+            # round-2 amendment: catalog rendered by top-level code
+            # (grid.innerHTML = `…${books.map(b => `…`)}…`) has no
+            # function unit — treat the whole script as one
+            sig = fragment_card(literals(src))
+            if sig:
+                found = [(None, src, sig, 0, "template")]
+        for f in found:
+            facs.append((idx,) + f)
+            if f[0]:
+                name_owners.setdefault(f[0], set()).add(idx)
+    if not facs: return []
+    out = []
+    for own_idx, name, unit, sig, start, style in facs:
+        keys = receiver_keys_for(scripts, name, unit, start, own_idx, name_owners)
+        if not keys: continue
+        hosts = [el for el in doc.walk()
+                 if el.tag in ("ul","ol","div","section")
+                 and _host_matches(el, keys)
+                 and el.role() != "listbox"
+                 and _near_empty(el)]
+        if not hosts: continue
+        shape, img, act = sig
+        container = f"{hosts[0].tag}-grid"
+        out.append((container, shape, img, act, style))
+    return out[:2]   # distinct bound factories, capped per screen
+
+# =====================================================================
+# Script-confirm scan — verbatim judgment from v1
+# =====================================================================
+
+CONFIRM_RE = re.compile(r"(?:window\.|(?<![.\w]))confirm\s*\(")
+
+def script_dialogs(screen: Path, doc: Node):
+    src = "".join(s for _, s, _b in script_sources(screen, doc))
+    if CONFIRM_RE.search(src):
+        return [("dialog", ("window-confirm", "native-blocking", "n/a"))]
+    return []
+
+# =====================================================================
+# Substance predicates (panel amendment: contentless stubs are reported
+# apart and do not feed the richness denominator)
+# =====================================================================
+
+def substantive(family: str, anchor: Node) -> bool:
+    if anchor is None: return True          # script-lane instances render content
+    if family == "table":
+        # headers are substance: a thead-only table whose tbody is populated
+        # client-side is legitimate static-analysis credit (Round-1 corpus:
+        # the antigravity D orders tables); only the fully empty shell stubs
+        return any(n.tag in ("td", "th", "caption")
+                   or resolved_role(n) in ("cell", "gridcell", "columnheader")
+                   for n in anchor.walk() if n is not anchor)
+    if family == "dialog":
+        return (any(k.tag not in SKIP_TAGS for k in anchor.children)
+                or bool(anchor.text.strip())
+                or bool(anchor.get("aria-label") or anchor.get("aria-labelledby")))
+    if family == "form":
+        # a button-only form is real (the canonical <form method="dialog">
+        # confirm form in a real D run; cart-line remove forms) — only the
+        # truly empty <form></form> shell stubs (round-2 amendment)
+        return any((n.tag in ("input", "select", "textarea") and n.get("type") != "hidden")
+                   or n.tag == "button"
+                   or (n.tag == "input" and n.get("type") in ("submit", "button", "image"))
+                   for n in anchor.walk())
+    if family == "nav":
+        return any(n.tag == "a" and n.get("href") for n in anchor.walk())
+    return True   # toast: an empty live-region placeholder is the correct idiom
+
+# =====================================================================
+# Case D — richness census helper
+# =====================================================================
+
+NONSEM_RE = re.compile(r"modal|overlay|toast|snackbar|janela|aviso|notificacao", re.I)
+
+def nonsemantic_census(doc: Node, family_anchors: set):
+    """div/section whose class or id lexically claims modal/overlay/toast but
+    that is not (inside/containing) any detected family instance. Lexical, so
+    it is metadata with lower evidential weight — never a metric."""
+    hits = 0
+    for n in doc.find_all(lambda x: x.tag in ("div","section")):
+        if not (NONSEM_RE.search(n.get("class","")) or NONSEM_RE.search(n.get("id",""))):
+            continue
+        lineage = {id(n)} | {id(a) for a in _ancestors(n)} | {id(d) for d in _desc(n)}
+        if lineage & family_anchors: continue
+        hits += 1
+    return hits
+
+# =====================================================================
+# classify — the run-level report
+# =====================================================================
+
+DETECTORS = (dialogs, navs, forms, tables, toasts)
+COUNTED = ("nav", "card", "form", "dialog", "toast", "table")
+
+def _family_excess(family: str, entry: dict) -> int:
+    """Variant excess of one counted family. Partitioned families (nav by
+    slot, toast by channel) sum per-partition excess; tables sum a
+    structure dimension and a capability-gated state dimension; the rest
+    compare one global pool. Shape-indeterminate card signatures stay out
+    of variant identity."""
+    instances = entry["instances"]
+    if family == "table":
+        structure = {tuple(i["signature"]) for i in instances}
+        signals = {i["sort_signal"] for i in instances if i.get("sort_capable")}
+        excess = 0
+        if structure: excess += len(structure) - 1
+        if signals: excess += len(signals) - 1
+        return excess
+    pools = {}
+    for i in instances:
+        if i.get("shape_indeterminate"): continue
+        pools.setdefault(i.get("partition", ""), set()).add(tuple(i["signature"]))
+    return sum(len(v) - 1 for v in pools.values() if v)
+
+def classify(run_dir: Path) -> dict:
+    if not run_dir.is_dir():
+        return {"status": "missing", "screens": 0}
+    screens = sorted(run_dir.glob("*.html"))
+    if not screens:
+        return {"status": "no-data", "screens": 0}
+
+    fam = {f: [] for f in COUNTED}
+    excluded = {f: [] for f in COUNTED}
+    stubs = {f: [] for f in COUNTED}
+    script_refs, cards_js_meta = [], []
+    nonsem = 0
+    per_screen_records = []
+
+    for screen in screens:
+        doc = parse(screen)
+        anchors = set()
+        for det in DETECTORS:
+            for family, sig, anchor, extra in det(doc):
+                errs = instance_errors(anchor) if anchor is not None else []
+                rec = {"screen": screen.name, "signature": list(sig), "source": "dom"}
+                if extra: rec.update(extra)
+                if errs:
+                    rec["invalid_reason"] = errs[:3]
+                    excluded[family].append(rec)
+                elif not substantive(family, anchor):
+                    stubs[family].append(rec)
+                else:
+                    fam[family].append(rec)
+                if anchor is not None: anchors.add(id(anchor))
+        dom_cards = cards_dom(doc)
+        for sig, anchor, has_substance in dom_cards:
+            errs = instance_errors(anchor)
+            rec = {"screen": screen.name, "signature": list(sig), "source": "dom"}
+            if errs:
+                rec["invalid_reason"] = errs[:3]
+                excluded["card"].append(rec)
+            elif not has_substance:
+                stubs["card"].append(rec)
+            else:
+                fam["card"].append(rec)
+            anchors.add(id(anchor))
+        # Per-SCREEN dominance (panel amendment): a screen whose DOM already
+        # shows a card grid keeps its JS hits as metadata (no double count);
+        # screens without one adopt their bound factories as instances.
+        js_here = [{"screen": screen.name,
+                    "signature": [c, s if s else "unknown", i, a],
+                    "source": "script", "style": st,
+                    "shape_indeterminate": s is None}
+                   for (c, s, i, a, st) in cards_js(screen, doc)]
+        dom_here = any(r["screen"] == screen.name for r in fam["card"])
+        if dom_here:
+            cards_js_meta.extend(js_here)
+        else:
+            fam["card"].extend(js_here)
+        for family, sig in script_dialogs(screen, doc):
+            script_refs.append({"screen": screen.name, "signature": list(sig), "source": "script"})
+        per_screen_records.append((screen, doc, anchors))
+
+    # Dialog dominance stays run-level, mirroring frozen v1's pilot-calibrated
+    # window.confirm rule (a run with DOM dialogs keeps confirm refs as
+    # metadata; a run with none adopts them).
+    if fam["dialog"]:
+        confirm_meta = script_refs
+    else:
+        fam["dialog"] = script_refs; confirm_meta = []
+
+    for screen, doc, anchors in per_screen_records:
+        nonsem += nonsemantic_census(doc, anchors)
+
+    report = {"status": "ok", "screens": len(screens), "families": {},
+              "variant_excess": 0, "per_family_excess": {},
+              "script_confirm_refs": confirm_meta, "cards_js_refs": cards_js_meta}
+
+    for family, instances in fam.items():
+        screens_with = {i["screen"] for i in instances}
+        entry = {"instances": instances,
+                 "excluded": len(excluded[family]),
+                 "excluded_detail": excluded[family],
+                 "stubs": len(stubs[family]),
+                 "stub_detail": stubs[family],
+                 "screens_with_family": len(screens_with),
+                 "counted": len(screens_with) >= 2}
+        entry["variants"] = len({tuple(i["signature"]) for i in instances
+                                 if not i.get("shape_indeterminate")})
+        if family == "table":
+            capable = [i for i in instances if i.get("sort_capable")]
+            entry["state_variants_among_capable"] = len({i["sort_signal"] for i in capable})
+            entry["capable_instances"] = len(capable)
+        # round-2 amendment: a counted family whose every instance is
+        # shape-indeterminate has no measurable variant pool — reporting 0
+        # would present an unmeasured cell as a measured zero. It is
+        # flagged, excluded from the excess sum AND from families_counted.
+        entry["unmeasurable"] = bool(
+            entry["counted"] and instances
+            and all(i.get("shape_indeterminate") for i in instances))
+        if entry["unmeasurable"]:
+            report["per_family_excess"][family] = None
+        else:
+            excess = _family_excess(family, entry) if entry["counted"] else 0
+            report["per_family_excess"][family] = excess
+            report["variant_excess"] += excess
+        report["families"][family] = entry
+
+    # richness: sibling block, computed from the SAME substantive instances
+    per_family = {}
+    per_screen_fams = {s.name: set() for s in screens}
+    for family, instances in fam.items():
+        with_screens = {i["screen"] for i in instances}
+        sources = {"dom": sum(1 for i in instances if i["source"] == "dom"),
+                   "script": sum(1 for i in instances if i["source"] == "script")}
+        per_family[family] = {"instances": len(instances),
+                              "screens_with": len(with_screens),
+                              "stubs": len(stubs[family]),
+                              "sources": sources}
+        for s in with_screens: per_screen_fams[s].add(family)
+    n_screens = len(screens)
+    coverage_cells = sum(v["screens_with"] for v in per_family.values())
+    report["richness"] = {
+        "families_instantiated": sum(1 for v in per_family.values() if v["instances"]),
+        "families_counted": sum(1 for f in COUNTED
+                                if report["families"][f]["counted"]
+                                and not report["families"][f]["unmeasurable"]),
+        "families_unmeasurable": sum(1 for f in COUNTED if report["families"][f]["unmeasurable"]),
+        "total_instances": sum(v["instances"] for v in per_family.values()),
+        "coverage_cells": coverage_cells,
+        "coverage_ratio": round(coverage_cells / (len(COUNTED) * n_screens), 4),
+        "screens_multi_family": sum(1 for fams in per_screen_fams.values() if len(fams) >= 2),
+        "stub_instances": sum(len(v) for v in stubs.values()),
+        "per_family": per_family,
+        "nonsemantic_candidates": nonsem,
+    }
+    return report
+
+# =====================================================================
+# self-test
+# =====================================================================
+
+def self_test():
+    """Validate every calibrated behavior: real fixtures (Round 1's published
+    screens) + held-out synthetic counterfactuals (fixtures/consistency/),
+    including the adversarial panel's counter-fixtures. Missing fixtures are
+    a FAILURE, not a skip."""
+    here = Path(__file__).resolve().parent
+    screens_root = here.parent / "runs" / "study2" / "screens"
+    fixtures = here / "fixtures" / "consistency"
+    ok = True
+
+    def check(name, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {name}: got {got!r} want {want!r} {'ok' if good else 'SELF-TEST FAILURE'}")
+
+    if not screens_root.is_dir():
+        sys.exit(f"self-test needs Round 1 screens at {screens_root} (published on Zenodo)")
+    if not fixtures.is_dir():
+        sys.exit(f"self-test needs the held-out fixtures at {fixtures}")
+
+    runs = {p.name: classify(p) for p in sorted(screens_root.iterdir()) if p.is_dir()}
+    live = {k: v for k, v in runs.items() if v["status"] == "ok"}
+
+    print("case D0 — empty runs are no-data, never 'perfectly consistent':")
+    empty = [k for k, v in runs.items() if v["status"] == "no-data"]
+    check("codex dirs report no-data", all(k.startswith("codex") for k in empty) and len(empty) == 15, True)
+    check("live runs", len(live), 30)
+    check("a nonexistent path is 'missing', not 'no-data'",
+          classify(screens_root / "does-not-exist")["status"], "missing")
+
+    print("case A — capability gate: no run is punished for honest aria-sort:")
+    state_excess = {k: max(0, v["families"]["table"]["state_variants_among_capable"] - 1)
+                    for k, v in live.items() if v["families"]["table"]["counted"]}
+    check("table state dimension adds zero across all 30 real runs",
+          sum(state_excess.values()), 0)
+    d_runs = [k for k in live if "__D__" in k]
+    check("all 10 D runs carry a counted table family",
+          sum(1 for k in d_runs if live[k]["families"]["table"]["counted"]), 10)
+
+    print("case C — validity gate: exactly one run's main-nav ladder is excluded:")
+    excl = {k: sum(v["families"][f]["excluded"] for f in COUNTED) for k, v in live.items()}
+    check("antigravity D run3 exclusions", excl.get("antigravity__journey__D__run3"), 7)
+    check("exclusions anywhere else", sum(n for k, n in excl.items() if k != "antigravity__journey__D__run3"), 0)
+    r3 = live["antigravity__journey__D__run3"]["families"]["nav"]
+    check("run3 nav valid instances", len(r3["instances"]), 8)
+    check("run3 nav excess after exclusion",
+          live["antigravity__journey__D__run3"]["per_family_excess"]["nav"], 0)
+
+    print("case B — cards: the JS-rendered catalogs are visible:")
+    with_cards = [k for k, v in live.items() if v["families"]["card"]["instances"]]
+    check("runs with a detected card grid", len(with_cards), 30)
+    dom_lane = [k for k, v in live.items()
+                if any(i["source"] == "dom" for i in v["families"]["card"]["instances"])]
+    check("DOM-lane runs (v1 saw 3 of these)", len(dom_lane), 5)
+
+    print("case D — richness travels beside excess:")
+    ric_ok = all(set(v["richness"]) >= {"families_counted", "stub_instances", "per_family"}
+                 for v in live.values())
+    check("richness block complete on every live run", ric_ok, True)
+    poor = live["antigravity__journey__A__run1"]["richness"]
+    rich = live["claude-code__journey__D__run3"]["richness"]
+    check("calibration pair (families, instances, cells): antigravity A run1",
+          (poor["families_instantiated"], poor["total_instances"], poor["coverage_cells"]),
+          (4, 17, 17))
+    check("calibration pair (families, instances, cells): claude-code D run3",
+          (rich["families_instantiated"], rich["total_instances"], rich["coverage_cells"]),
+          (6, 32, 23))
+    check("nonsemantic census sees antigravity A run1's fake modals/toasts",
+          poor["nonsemantic_candidates"] > 0, True)
+
+    print("condition-blindness — same content, different directory name, same output:")
+    import shutil, tempfile
+    src = fixtures / "blind-probe"
+    check("blind-probe fixture present (mandatory)", src.is_dir(), True)
+    if src.is_dir():
+        with tempfile.TemporaryDirectory() as td:
+            a, d = Path(td) / "agent__journey__A__run1", Path(td) / "agent__journey__D__run1"
+            shutil.copytree(src, a); shutil.copytree(src, d)
+            check("classify(A-named) == classify(D-named)", classify(a) == classify(d), True)
+
+    print("synthetic counterfactuals (held out — behaviors the real corpus lacks):")
+    def fx(name): return classify(fixtures / name)
+    r = fx("table-signals-diverge")
+    check("two capable tables, divergent signals -> state excess 1",
+          r["per_family_excess"]["table"], 1)
+    check("  (and their structure agrees)", r["families"]["table"]["variants"], 1)
+    r = fx("table-static-vs-sorted")
+    check("static table vs honest sortable -> no state excess",
+          r["per_family_excess"]["table"], 0)
+    r = fx("table-span-onclick")
+    check("onclick on a span inside th -> capable (divergent signals score)",
+          r["per_family_excess"]["table"], 1)
+    r = fx("table-role-grid")
+    check("ARIA grid with role=columnheader -> capable, signals compared",
+          r["per_family_excess"]["table"], 1)
+    r = fx("ladder-broken")
+    check("broken menu ladder -> excluded, not a variant", r["families"]["nav"]["excluded"], 2)
+    check("  remaining nav excess", r["per_family_excess"]["nav"], 0)
+    r = fx("ladder-delegated")
+    check("role=none delegation ladder -> valid", r["families"]["nav"]["excluded"], 0)
+    r = fx("ladder-div-links")
+    check("div[role=menu] of plain links/buttons -> excluded (implicit roles)",
+          r["families"]["nav"]["excluded"], 2)
+    r = fx("composite-no-items")
+    check("announced composite with content but zero items -> excluded",
+          r["families"]["nav"]["excluded"], 2)
+    r = fx("cards-css-cover")
+    check("static grid with CSS covers -> detected", r["families"]["card"]["instances"] != [], True)
+    r = fx("cards-js-template")
+    check("empty grid + JS factory -> detected via script lane",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-authoring-styles")
+    check("same rendered card, template vs builder authoring -> 0 excess",
+          r["per_family_excess"]["card"], 0)
+    r = fx("cards-mixed-grid")
+    check("two conventions inside ONE grid -> both seen, excess 1",
+          r["per_family_excess"]["card"], 1)
+    r = fx("cards-dead-factory")
+    check("unbound second factory does not score",
+          r["families"]["card"]["variants"], 1)
+    r = fx("cards-minified")
+    check("minified one-line JS still binds the factory",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-arrow-factory")
+    check("arrow-assigned factory with render site after it -> detected",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-brace-in-string")
+    check("'}' inside a string/comment does not truncate the factory",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-template-inert")
+    check("<template> sample card is not a DOM instance; JS lane scores",
+          (any(i["source"] == "dom" for i in r["families"]["card"]["instances"]),
+           any(i["source"] == "script" for i in r["families"]["card"]["instances"])),
+          (False, True))
+    r = fx("cards-screen-dominance")
+    check("per-screen dominance: DOM screen + JS screens all count",
+          r["families"]["card"]["screens_with_family"], 3)
+    r = fx("toast-dual-severity")
+    check("uniform status+alert pair (prescribed purpose split) -> 0 excess",
+          r["per_family_excess"]["toast"], 0)
+    r = fx("toast-channel-diverge")
+    check("two conventions in ONE channel -> excess 1",
+          r["per_family_excess"]["toast"], 1)
+    r = fx("nav-secondary-static")
+    check("dropdown main + static footer navs (both uniform) -> 0 excess",
+          r["per_family_excess"]["nav"], 0)
+    r = fx("nav-primary-diverge")
+    check("primary nav changing mechanism across screens -> excess 1",
+          r["per_family_excess"]["nav"], 1)
+    r = fx("richness-stubs")
+    check("contentless stubs feed stub_instances, not the denominator",
+          (r["richness"]["families_counted"], r["richness"]["stub_instances"] > 0),
+          (1, True))
+    r = fx("poor-consistent")
+    check("2-family run: excess 0 with denominator visible",
+          (r["variant_excess"], r["richness"]["families_counted"]), (0, 2))
+
+    print("second panel round — the amended behaviors, held out:")
+    r = fx("toast-nested-region")
+    check("live-region wrapper + inner toast = ONE widget -> 0 excess",
+          (r["per_family_excess"]["toast"], len(r["families"]["toast"]["instances"])), (0, 2))
+    r = fx("toast-case-mech")
+    check("aria-live value compares case-insensitively -> 1 variant",
+          r["families"]["toast"]["variants"], 1)
+    r = fx("cards-nested-template")
+    check("nested template + concise-arrow .map (the modern idiom) -> detected",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-chained-receiver")
+    check("chained no-variable receiver -> detected",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-class-receiver")
+    check("querySelector('.class') receiver -> detected",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-placeholder-host")
+    check("skeleton/noscript children do not disqualify the host",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("cards-name-collision")
+    check("dead same-name factory in a second script does not score",
+          r["families"]["card"]["variants"], 1)
+    r = fx("cards-svg-badge")
+    check("decorative svg badge does not split a uniform grid",
+          (r["families"]["card"]["variants"], r["per_family_excess"]["card"]), (1, 0))
+    r = fx("cards-all-indeterminate")
+    check("all-indeterminate card pool -> unmeasurable, out of the denominator",
+          (r["per_family_excess"]["card"], r["families"]["card"]["unmeasurable"],
+           r["richness"]["families_unmeasurable"]), (None, True, 1))
+    r = fx("cards-regex-literal")
+    check("regex literal with a quote above the factory -> still detected",
+          any(i["source"] == "script" for i in r["families"]["card"]["instances"]), True)
+    r = fx("table-checkbox-th")
+    check("select-all checkbox in th does not open the sort gate",
+          r["per_family_excess"]["table"], 0)
+    r = fx("table-bare-th")
+    check("bare first-row th heads columns (idiom-independent gate) -> +1",
+          r["per_family_excess"]["table"], 1)
+    r = fx("form-button-only")
+    check("button-only dialog-method form is substantive",
+          (r["families"]["form"]["stubs"], r["families"]["form"]["counted"]), (0, True))
+    r = fx("nav-footer-only-screen")
+    check("footer-only screen promotes nothing -> 0 excess",
+          r["per_family_excess"]["nav"], 0)
+    r = fx("single-screen-family")
+    check("one-screen family is not counted (real falsifiable denominator check)",
+          (r["families"]["dialog"]["counted"], r["richness"]["families_counted"]), (False, 1))
+
+    print("self-test:", "PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)
+
+if __name__ == "__main__":
+    if "--self-test" in sys.argv:
+        self_test()
+    args = [a for a in sys.argv[1:] if a != "--self-test"]
+    if not args:
+        print(__doc__); sys.exit(0)
+    for arg in args:
+        r = classify(Path(arg))
+        print(json.dumps({arg: r}, indent=1, ensure_ascii=False))

--- a/benchmark/round2/fixtures/consistency/blind-probe/index.html
+++ b/benchmark/round2/fixtures/consistency/blind-probe/index.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Sonda</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="orders.html">Pedidos</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+</ul></nav>
+<table>
+ <thead><tr><th scope="col">Item</th><th scope="col">Estado</th></tr></thead>
+ <tbody><tr><td>Livro</td><td>Enviado</td></tr></tbody>
+</table>
+<div role="status" aria-live="polite"></div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/blind-probe/orders.html
+++ b/benchmark/round2/fixtures/consistency/blind-probe/orders.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Sonda</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="orders.html">Pedidos</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+</ul></nav>
+<table>
+ <thead><tr><th scope="col">Item</th><th scope="col">Estado</th></tr></thead>
+ <tbody><tr><td>Livro</td><td>Enviado</td></tr></tbody>
+</table>
+<div role="status" aria-live="polite"></div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-all-indeterminate/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-all-indeterminate/index.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+function bookCard(b) {
+  const wrapper = document.createElement('li');
+  wrapper.innerHTML = `<img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button>`;
+  return wrapper;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.appendChild(bookCard(b)); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-all-indeterminate/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-all-indeterminate/search.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+function bookCard(b) {
+  const wrapper = document.createElement('li');
+  wrapper.innerHTML = `<img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button>`;
+  return wrapper;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.appendChild(bookCard(b)); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-arrow-factory/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-arrow-factory/index.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+const bookCard = (b) => {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+};
+document.addEventListener('DOMContentLoaded', function () {
+  const grid = document.getElementById('grid');
+  grid.innerHTML = window.BOOKS.map(bookCard).join('');
+});
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-arrow-factory/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-arrow-factory/search.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+const bookCard = (b) => {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+};
+document.addEventListener('DOMContentLoaded', function () {
+  const grid = document.getElementById('grid');
+  grid.innerHTML = window.BOOKS.map(bookCard).join('');
+});
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-authoring-styles/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-authoring-styles/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="featured-grid"></div>
+<script>
+const grid = document.getElementById('featured-grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-authoring-styles/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-authoring-styles/search.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="pt-BR"><head><title>Busca</title></head><body>
+<div class="grid" id="results-grid"></div>
+<script>
+const grid = document.getElementById('results-grid');
+function el(tag, attrs) { return document.createElement(tag); }
+function bookCard(b) {
+  const li = el('li', {});
+  li.appendChild(el('img', {}));
+  li.appendChild(el('h3', {}));
+  li.appendChild(el('button', {}));
+  return li;
+}
+window.BOOKS.forEach(function (b) { grid.appendChild(bookCard(b)); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-brace-in-string/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-brace-in-string/index.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+// helper antigo removido: renderAll(list) { ... })
+function bookCard(b) {
+  const suffix = "}";
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-brace-in-string/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-brace-in-string/search.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+// helper antigo removido: renderAll(list) { ... })
+function bookCard(b) {
+  const suffix = "}";
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-chained-receiver/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-chained-receiver/index.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="book-grid"></div>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+document.getElementById('book-grid').innerHTML = window.BOOKS.map(bookCard).join('');
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-chained-receiver/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-chained-receiver/search.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="book-grid"></div>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+document.getElementById('book-grid').innerHTML = window.BOOKS.map(bookCard).join('');
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-class-receiver/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-class-receiver/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="book-grid"></div>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.querySelector('.book-grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-class-receiver/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-class-receiver/search.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="book-grid"></div>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.querySelector('.book-grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-css-cover/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-css-cover/index.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<ul class="book-grid">
+ <li><article class="book-card"><div class="cover" aria-hidden="true"></div><h3><a href="book.html">Dom Casmurro</a></h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><div class="cover" aria-hidden="true"></div><h3><a href="book.html">Quincas Borba</a></h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><div class="cover" aria-hidden="true"></div><h3><a href="book.html">Helena</a></h3><button type="button">Adicionar</button></article></li>
+</ul>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-css-cover/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-css-cover/search.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<ul class="book-grid">
+ <li><article class="book-card"><div class="cover" aria-hidden="true"></div><h3><a href="book.html">Dom Casmurro</a></h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><div class="cover" aria-hidden="true"></div><h3><a href="book.html">Quincas Borba</a></h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><div class="cover" aria-hidden="true"></div><h3><a href="book.html">Helena</a></h3><button type="button">Adicionar</button></article></li>
+</ul>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-dead-factory/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-dead-factory/index.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+const grid = document.getElementById('grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+function promoTile(p) {
+  return `<div class="promo"><img src="${p.banner}" alt=""><a href="${p.url}">Ver oferta</a></div>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+// promoTile nunca é chamada nem ligada a um contêiner
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-dead-factory/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-dead-factory/search.html
@@ -1,0 +1,14 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+const grid = document.getElementById('grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+function promoTile(p) {
+  return `<div class="promo"><img src="${p.banner}" alt=""><a href="${p.url}">Ver oferta</a></div>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+// promoTile nunca é chamada nem ligada a um contêiner
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-js-template/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-js-template/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="featured-grid"></div>
+<script>
+const grid = document.getElementById('featured-grid');
+function bookCard(b) {
+  return `<article class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></article>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-js-template/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-js-template/search.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="featured-grid"></div>
+<script>
+const grid = document.getElementById('featured-grid');
+function bookCard(b) {
+  return `<article class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></article>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-minified/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-minified/index.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>function makeCard(b){return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`}const grid=document.getElementById("grid");window.BOOKS.forEach(function(b){grid.innerHTML+=makeCard(b)});</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-minified/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-minified/search.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>function makeCard(b){return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`}const grid=document.getElementById("grid");window.BOOKS.forEach(function(b){grid.innerHTML+=makeCard(b)});</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-mixed-grid/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-mixed-grid/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<div class="catalog">
+ <div class="card"><img src="c1.png" alt="Dom Casmurro"><h3>Dom Casmurro</h3><button type="button">Comprar</button></div>
+ <div class="card"><img src="c2.png" alt="Quincas Borba"><h3>Quincas Borba</h3><button type="button">Comprar</button></div>
+ <div class="card"><img src="c3.png" alt="Helena"><h3>Helena</h3><button type="button">Comprar</button></div>
+ <div class="card mini"><span class="thumb"></span><a href="book.html">Iaiá Garcia</a></div>
+ <div class="card mini"><span class="thumb"></span><a href="book.html">Esaú e Jacó</a></div>
+ <div class="card mini"><span class="thumb"></span><a href="book.html">Memorial de Aires</a></div>
+</div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-mixed-grid/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-mixed-grid/search.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<div class="catalog">
+ <div class="card"><img src="c1.png" alt="Dom Casmurro"><h3>Dom Casmurro</h3><button type="button">Comprar</button></div>
+ <div class="card"><img src="c2.png" alt="Quincas Borba"><h3>Quincas Borba</h3><button type="button">Comprar</button></div>
+ <div class="card"><img src="c3.png" alt="Helena"><h3>Helena</h3><button type="button">Comprar</button></div>
+ <div class="card mini"><span class="thumb"></span><a href="book.html">Iaiá Garcia</a></div>
+ <div class="card mini"><span class="thumb"></span><a href="book.html">Esaú e Jacó</a></div>
+ <div class="card mini"><span class="thumb"></span><a href="book.html">Memorial de Aires</a></div>
+</div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-name-collision/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-name-collision/index.html
@@ -1,0 +1,11 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script src="js/legacy.js"></script>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-name-collision/js/legacy.js
+++ b/benchmark/round2/fixtures/consistency/cards-name-collision/js/legacy.js
@@ -1,0 +1,6 @@
+// biblioteca antiga carregada mas nunca usada nesta página
+function bookCard(b) {
+  return `<div class="old-card"><img src="${b.img}" alt=""><a href="${b.url}">Ver</a></div>`;
+}
+window.LEGACY_BOOKS = [];
+window.LEGACY_BOOKS.forEach(function (b) { /* nada renderiza aqui */ });

--- a/benchmark/round2/fixtures/consistency/cards-name-collision/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-name-collision/search.html
@@ -1,0 +1,11 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script src="js/legacy.js"></script>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-nested-template/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-nested-template/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+function renderCatalog() {
+  const grid = document.getElementById('grid');
+  grid.innerHTML = `<ul class="books">${window.BOOKS.map(b => `<li class="book-card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`).join('')}</ul>`;
+}
+renderCatalog();
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-nested-template/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-nested-template/search.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+function renderCatalog() {
+  const grid = document.getElementById('grid');
+  grid.innerHTML = `<ul class="books">${window.BOOKS.map(b => `<li class="book-card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`).join('')}</ul>`;
+}
+renderCatalog();
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-placeholder-host/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-placeholder-host/index.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid">
+ <div class="loading-skeleton">Carregando…</div>
+ <noscript><p>Ative o JavaScript para ver o catálogo.</p></noscript>
+</div>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-placeholder-host/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-placeholder-host/search.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid">
+ <div class="loading-skeleton">Carregando…</div>
+ <noscript><p>Ative o JavaScript para ver o catálogo.</p></noscript>
+</div>
+<script>
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-regex-literal/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-regex-literal/index.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+function esc(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+}
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${esc(b.title)}"><h3>${esc(b.title)}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-regex-literal/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-regex-literal/search.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+function esc(s) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
+}
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${esc(b.title)}"><h3>${esc(b.title)}</h3><button type="button">Comprar</button></li>`;
+}
+const grid = document.getElementById('grid');
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-screen-dominance/cart.html
+++ b/benchmark/round2/fixtures/consistency/cards-screen-dominance/cart.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Busca</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+const grid = document.getElementById('grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-screen-dominance/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-screen-dominance/index.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<ul class="book-grid">
+ <li><article class="book-card"><img src="c1.png" alt="Dom Casmurro"><h3><a href="book.html">Dom Casmurro</a></h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><img src="c2.png" alt="Quincas Borba"><h3><a href="book.html">Quincas Borba</a></h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><img src="c3.png" alt="Helena"><h3><a href="book.html">Helena</a></h3><button type="button">Adicionar</button></article></li>
+</ul>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-screen-dominance/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-screen-dominance/search.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Busca</title></head><body>
+<div class="grid" id="grid"></div>
+<script>
+const grid = document.getElementById('grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-svg-badge/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-svg-badge/index.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<ul class="book-grid">
+ <li><article class="book-card"><img src="c1.png" alt="Dom Casmurro"><h3>Dom Casmurro</h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><img src="c2.png" alt="Quincas Borba"><svg aria-hidden="true" class="badge-star"></svg><h3>Quincas Borba</h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><img src="c3.png" alt="Helena"><h3>Helena</h3><button type="button">Adicionar</button></article></li>
+</ul>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-svg-badge/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-svg-badge/search.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="pt-BR"><head><title>Destaques</title></head><body>
+<ul class="book-grid">
+ <li><article class="book-card"><img src="c1.png" alt="Dom Casmurro"><h3>Dom Casmurro</h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><img src="c2.png" alt="Quincas Borba"><svg aria-hidden="true" class="badge-star"></svg><h3>Quincas Borba</h3><button type="button">Adicionar</button></article></li>
+ <li><article class="book-card"><img src="c3.png" alt="Helena"><h3>Helena</h3><button type="button">Adicionar</button></article></li>
+</ul>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-template-inert/index.html
+++ b/benchmark/round2/fixtures/consistency/cards-template-inert/index.html
@@ -1,0 +1,17 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<template id="card-sample">
+ <div class="sample">
+  <div class="card"><img src="s.png" alt="a"><h3>A</h3><button type="button">Comprar</button></div>
+  <div class="card"><img src="s.png" alt="b"><h3>B</h3><button type="button">Comprar</button></div>
+  <div class="card"><img src="s.png" alt="c"><h3>C</h3><button type="button">Comprar</button></div>
+ </div>
+</template>
+<div class="grid" id="grid"></div>
+<script>
+const grid = document.getElementById('grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/cards-template-inert/search.html
+++ b/benchmark/round2/fixtures/consistency/cards-template-inert/search.html
@@ -1,0 +1,17 @@
+<!doctype html><html lang="pt-BR"><head><title>Catálogo</title></head><body>
+<template id="card-sample">
+ <div class="sample">
+  <div class="card"><img src="s.png" alt="a"><h3>A</h3><button type="button">Comprar</button></div>
+  <div class="card"><img src="s.png" alt="b"><h3>B</h3><button type="button">Comprar</button></div>
+  <div class="card"><img src="s.png" alt="c"><h3>C</h3><button type="button">Comprar</button></div>
+ </div>
+</template>
+<div class="grid" id="grid"></div>
+<script>
+const grid = document.getElementById('grid');
+function bookCard(b) {
+  return `<li class="card"><img src="${b.cover}" alt="${b.title}"><h3>${b.title}</h3><button type="button">Comprar</button></li>`;
+}
+window.BOOKS.forEach(function (b) { grid.innerHTML += bookCard(b); });
+</script>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/composite-no-items/index.html
+++ b/benchmark/round2/fixtures/consistency/composite-no-items/index.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <div role="tablist">
+  <div>Romance</div>
+  <div>Poesia</div>
+ </div>
+ <ul><li><a href="index.html">Início</a></li><li><a href="search.html">Busca</a></li><li><a href="cart.html">Carrinho</a></li></ul>
+</nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/composite-no-items/search.html
+++ b/benchmark/round2/fixtures/consistency/composite-no-items/search.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <div role="tablist">
+  <div>Romance</div>
+  <div>Poesia</div>
+ </div>
+ <ul><li><a href="index.html">Início</a></li><li><a href="search.html">Busca</a></li><li><a href="cart.html">Carrinho</a></li></ul>
+</nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/form-button-only/cart.html
+++ b/benchmark/round2/fixtures/consistency/form-button-only/cart.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Carrinho</title></head><body>
+<dialog aria-labelledby="confirm-title">
+ <h2 id="confirm-title">Remover item?</h2>
+ <form method="dialog">
+  <button value="cancel">Cancelar</button>
+  <button value="confirm">Remover</button>
+ </form>
+</dialog>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/form-button-only/orders.html
+++ b/benchmark/round2/fixtures/consistency/form-button-only/orders.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Carrinho</title></head><body>
+<dialog aria-labelledby="confirm-title">
+ <h2 id="confirm-title">Remover item?</h2>
+ <form method="dialog">
+  <button value="cancel">Cancelar</button>
+  <button value="confirm">Remover</button>
+ </form>
+</dialog>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/ladder-broken/index.html
+++ b/benchmark/round2/fixtures/consistency/ladder-broken/index.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <button aria-expanded="false" aria-controls="cats">Categorias</button>
+ <ul id="cats" role="menu" hidden>
+  <li><a role="menuitem" href="search.html">Romance</a></li>
+  <li><a role="menuitem" href="search.html">Poesia</a></li>
+ </ul>
+</nav>
+<main><p>Conteúdo.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/ladder-broken/search.html
+++ b/benchmark/round2/fixtures/consistency/ladder-broken/search.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <button aria-expanded="false" aria-controls="cats">Categorias</button>
+ <ul id="cats" role="menu" hidden>
+  <li><a role="menuitem" href="search.html">Romance</a></li>
+  <li><a role="menuitem" href="search.html">Poesia</a></li>
+ </ul>
+</nav>
+<main><p>Conteúdo.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/ladder-delegated/index.html
+++ b/benchmark/round2/fixtures/consistency/ladder-delegated/index.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <button aria-expanded="false" aria-controls="cats">Categorias</button>
+ <ul id="cats" role="menu" hidden>
+  <li role="none"><a role="menuitem" href="search.html">Romance</a></li>
+  <li role="none"><a role="menuitem" href="search.html">Poesia</a></li>
+ </ul>
+</nav>
+<main><p>Conteúdo.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/ladder-delegated/search.html
+++ b/benchmark/round2/fixtures/consistency/ladder-delegated/search.html
@@ -1,0 +1,15 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <button aria-expanded="false" aria-controls="cats">Categorias</button>
+ <ul id="cats" role="menu" hidden>
+  <li role="none"><a role="menuitem" href="search.html">Romance</a></li>
+  <li role="none"><a role="menuitem" href="search.html">Poesia</a></li>
+ </ul>
+</nav>
+<main><p>Conteúdo.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/ladder-div-links/index.html
+++ b/benchmark/round2/fixtures/consistency/ladder-div-links/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <button aria-expanded="false" aria-controls="cats">Categorias</button>
+ <div id="cats" role="menu" hidden>
+  <a href="search.html">Romance</a>
+  <button type="button">Poesia</button>
+ </div>
+</nav>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/ladder-div-links/search.html
+++ b/benchmark/round2/fixtures/consistency/ladder-div-links/search.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <button aria-expanded="false" aria-controls="cats">Categorias</button>
+ <div id="cats" role="menu" hidden>
+  <a href="search.html">Romance</a>
+  <button type="button">Poesia</button>
+ </div>
+</nav>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-footer-only-screen/checkout.html
+++ b/benchmark/round2/fixtures/consistency/nav-footer-only-screen/checkout.html
@@ -1,0 +1,7 @@
+<!doctype html><html lang="pt-BR"><head><title>Pagamento</title></head><body>
+<main><p>Fluxo de pagamento sem distrações.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-footer-only-screen/index.html
+++ b/benchmark/round2/fixtures/consistency/nav-footer-only-screen/index.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+ <li><button aria-expanded="false" aria-controls="c">Categorias</button><ul id="c" hidden><li><a href="search.html">Romance</a></li></ul></li>
+</ul></nav>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-footer-only-screen/search.html
+++ b/benchmark/round2/fixtures/consistency/nav-footer-only-screen/search.html
@@ -1,0 +1,13 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+ <li><button aria-expanded="false" aria-controls="c">Categorias</button><ul id="c" hidden><li><a href="search.html">Romance</a></li></ul></li>
+</ul></nav>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-primary-diverge/index.html
+++ b/benchmark/round2/fixtures/consistency/nav-primary-diverge/index.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <ul>
+  <li><a href="index.html">Início</a></li>
+  <li><a href="search.html">Busca</a></li>
+  <li><a href="cart.html">Carrinho</a></li>
+  <li><button aria-expanded="false" aria-controls="cats">Categorias</button>
+   <ul id="cats" hidden><li><a href="search.html">Romance</a></li></ul>
+  </li>
+ </ul>
+</nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-primary-diverge/search.html
+++ b/benchmark/round2/fixtures/consistency/nav-primary-diverge/search.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Busca</title></head><body>
+<nav aria-label="Principal">
+ <ul>
+  <li><a href="index.html">Início</a></li>
+  <li><a href="search.html">Busca</a></li>
+  <li><a href="cart.html">Carrinho</a></li>
+  <li><details><summary>Categorias</summary>
+   <ul><li><a href="search.html">Romance</a></li></ul>
+  </details></li>
+ </ul>
+</nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-secondary-static/index.html
+++ b/benchmark/round2/fixtures/consistency/nav-secondary-static/index.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <ul>
+  <li><a href="index.html">Início</a></li>
+  <li><a href="search.html">Busca</a></li>
+  <li><a href="cart.html">Carrinho</a></li>
+  <li><a href="sell.html">Vender</a></li>
+  <li><button aria-expanded="false" aria-controls="cats">Categorias</button>
+   <ul id="cats" hidden><li><a href="search.html">Romance</a></li><li><a href="search.html">Poesia</a></li></ul>
+  </li>
+ </ul>
+</nav>
+<main><p>Conteúdo.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/nav-secondary-static/search.html
+++ b/benchmark/round2/fixtures/consistency/nav-secondary-static/search.html
@@ -1,0 +1,18 @@
+<!doctype html><html lang="pt-BR"><head><title>Livraria</title></head><body>
+<nav aria-label="Principal">
+ <ul>
+  <li><a href="index.html">Início</a></li>
+  <li><a href="search.html">Busca</a></li>
+  <li><a href="cart.html">Carrinho</a></li>
+  <li><a href="sell.html">Vender</a></li>
+  <li><button aria-expanded="false" aria-controls="cats">Categorias</button>
+   <ul id="cats" hidden><li><a href="search.html">Romance</a></li><li><a href="search.html">Poesia</a></li></ul>
+  </li>
+ </ul>
+</nav>
+<main><p>Conteúdo.</p></main>
+<nav aria-label="Rodapé"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="search.html">Busca</a></li>
+</ul></nav>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/poor-consistent/cart.html
+++ b/benchmark/round2/fixtures/consistency/poor-consistent/cart.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+</ul></nav>
+<form>
+ <label for="q">Busca</label><input id="q" type="text">
+ <label for="cat">Categoria</label><select id="cat"><option>Todas</option></select>
+ <button type="submit">Buscar</button>
+</form>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/poor-consistent/index.html
+++ b/benchmark/round2/fixtures/consistency/poor-consistent/index.html
@@ -1,0 +1,12 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+</ul></nav>
+<form>
+ <label for="q">Busca</label><input id="q" type="text">
+ <label for="cat">Categoria</label><select id="cat"><option>Todas</option></select>
+ <button type="submit">Buscar</button>
+</form>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/richness-stubs/cart.html
+++ b/benchmark/round2/fixtures/consistency/richness-stubs/cart.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+</ul></nav>
+<table></table>
+<dialog></dialog>
+<form></form>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/richness-stubs/index.html
+++ b/benchmark/round2/fixtures/consistency/richness-stubs/index.html
@@ -1,0 +1,10 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+</ul></nav>
+<table></table>
+<dialog></dialog>
+<form></form>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/single-screen-family/cart.html
+++ b/benchmark/round2/fixtures/consistency/single-screen-family/cart.html
@@ -1,0 +1,8 @@
+<!doctype html><html lang="pt-BR"><head><title>Carrinho</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+</ul></nav>
+<main><p>Carrinho.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/single-screen-family/index.html
+++ b/benchmark/round2/fixtures/consistency/single-screen-family/index.html
@@ -1,0 +1,8 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<nav aria-label="Principal"><ul>
+ <li><a href="index.html">Início</a></li>
+ <li><a href="cart.html">Carrinho</a></li>
+ <li><a href="sell.html">Vender</a></li>
+</ul></nav>
+<dialog aria-labelledby="t"><h2 id="t">Aviso</h2><p>Só nesta tela.</p></dialog>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-bare-th/dashboard.html
+++ b/benchmark/round2/fixtures/consistency/table-bare-th/dashboard.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Painel</title></head><body>
+<table>
+ <tr><th aria-sort="ascending"><button type="button">Título</button></th><th><button type="button">Preço</button></th></tr>
+ <tr><td>Dom Casmurro</td><td>R$ 30</td></tr>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-bare-th/orders.html
+++ b/benchmark/round2/fixtures/consistency/table-bare-th/orders.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Pedidos</title></head><body>
+<table>
+ <tr><th><button type="button">Data</button></th><th><button type="button">Total</button></th></tr>
+ <tr><td>2026-08-01</td><td>R$ 55</td></tr>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-checkbox-th/dashboard.html
+++ b/benchmark/round2/fixtures/consistency/table-checkbox-th/dashboard.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Painel</title></head><body>
+<table>
+ <thead><tr>
+  <th scope="col" aria-sort="ascending"><button type="button">Título</button></th>
+  <th scope="col">Preço</th>
+ </tr></thead>
+ <tbody><tr><td>Dom Casmurro</td><td>R$ 30</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-checkbox-th/orders.html
+++ b/benchmark/round2/fixtures/consistency/table-checkbox-th/orders.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Pedidos</title></head><body>
+<table>
+ <thead><tr>
+  <th scope="col"><input type="checkbox" onclick="toggleAll()" aria-label="Selecionar tudo"></th>
+  <th scope="col">Data</th>
+ </tr></thead>
+ <tbody><tr><td><input type="checkbox"></td><td>2026-08-01</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-role-grid/dashboard.html
+++ b/benchmark/round2/fixtures/consistency/table-role-grid/dashboard.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Painel</title></head><body>
+<div role="grid">
+ <div role="row"><div role="columnheader" aria-sort="ascending"><button type="button">Título</button></div><div role="columnheader"><button type="button">Preço</button></div></div>
+ <div role="row"><div role="gridcell">Dom Casmurro</div><div role="gridcell">R$ 30</div></div>
+</div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-role-grid/orders.html
+++ b/benchmark/round2/fixtures/consistency/table-role-grid/orders.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Pedidos</title></head><body>
+<div role="grid">
+ <div role="row"><div role="columnheader"><button type="button">Data</button></div><div role="columnheader"><button type="button">Total</button></div></div>
+ <div role="row"><div role="gridcell">2026-08-01</div><div role="gridcell">R$ 55</div></div>
+</div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-signals-diverge/dashboard.html
+++ b/benchmark/round2/fixtures/consistency/table-signals-diverge/dashboard.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Painel</title></head><body>
+<table>
+ <thead><tr>
+  <th scope="col" aria-sort="ascending"><button type="button">Título</button></th>
+  <th scope="col"><button type="button">Preço</button></th>
+ </tr></thead>
+ <tbody><tr><td>Dom Casmurro</td><td>R$ 30</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-signals-diverge/orders.html
+++ b/benchmark/round2/fixtures/consistency/table-signals-diverge/orders.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Pedidos</title></head><body>
+<table>
+ <thead><tr>
+  <th scope="col"><button type="button">Data</button></th>
+  <th scope="col"><button type="button">Total</button></th>
+ </tr></thead>
+ <tbody><tr><td>2026-08-01</td><td>R$ 55</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-span-onclick/dashboard.html
+++ b/benchmark/round2/fixtures/consistency/table-span-onclick/dashboard.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Painel</title></head><body>
+<table>
+ <thead><tr><th scope="col" aria-sort="ascending"><span class="sortable" onclick="sortBy('t')">Título</span></th><th scope="col">Preço</th></tr></thead>
+ <tbody><tr><td>Dom Casmurro</td><td>R$ 30</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-span-onclick/orders.html
+++ b/benchmark/round2/fixtures/consistency/table-span-onclick/orders.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Pedidos</title></head><body>
+<table>
+ <thead><tr><th scope="col"><span class="sortable" onclick="sortBy('d')">Data</span></th><th scope="col">Total</th></tr></thead>
+ <tbody><tr><td>2026-08-01</td><td>R$ 55</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-static-vs-sorted/dashboard.html
+++ b/benchmark/round2/fixtures/consistency/table-static-vs-sorted/dashboard.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Painel</title></head><body>
+<table>
+ <thead><tr><th scope="col">Métrica</th><th scope="col">Valor</th></tr></thead>
+ <tbody><tr><td>Vendas</td><td>12</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/table-static-vs-sorted/orders.html
+++ b/benchmark/round2/fixtures/consistency/table-static-vs-sorted/orders.html
@@ -1,0 +1,9 @@
+<!doctype html><html lang="pt-BR"><head><title>Pedidos</title></head><body>
+<table>
+ <thead><tr>
+  <th scope="col" aria-sort="none"><button type="button">Data</button></th>
+  <th scope="col"><button type="button">Total</button></th>
+ </tr></thead>
+ <tbody><tr><td>2026-08-02</td><td>R$ 40</td></tr></tbody>
+</table>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-case-mech/cart.html
+++ b/benchmark/round2/fixtures/consistency/toast-case-mech/cart.html
@@ -1,0 +1,3 @@
+<!doctype html><html lang="pt-BR"><head><title>Carrinho</title></head><body>
+<div aria-live="polite" class="toast" hidden></div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-case-mech/index.html
+++ b/benchmark/round2/fixtures/consistency/toast-case-mech/index.html
@@ -1,0 +1,3 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<div aria-live="Polite" class="toast" hidden></div>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-channel-diverge/cart.html
+++ b/benchmark/round2/fixtures/consistency/toast-channel-diverge/cart.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="pt-BR"><head><title>Carrinho</title></head><body>
+<div aria-live="polite" class="toast" hidden></div>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-channel-diverge/index.html
+++ b/benchmark/round2/fixtures/consistency/toast-channel-diverge/index.html
@@ -1,0 +1,4 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<div role="status" class="toast" hidden></div>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-dual-severity/cart.html
+++ b/benchmark/round2/fixtures/consistency/toast-dual-severity/cart.html
@@ -1,0 +1,5 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<div role="status" class="toast" hidden></div>
+<div role="alert" class="toast toast-error" hidden></div>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-dual-severity/index.html
+++ b/benchmark/round2/fixtures/consistency/toast-dual-severity/index.html
@@ -1,0 +1,5 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<div role="status" class="toast" hidden></div>
+<div role="alert" class="toast toast-error" hidden></div>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-nested-region/index.html
+++ b/benchmark/round2/fixtures/consistency/toast-nested-region/index.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<div id="progress-area" aria-live="polite">
+ <div id="upload-status" role="status"></div>
+</div>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/fixtures/consistency/toast-nested-region/sell.html
+++ b/benchmark/round2/fixtures/consistency/toast-nested-region/sell.html
@@ -1,0 +1,6 @@
+<!doctype html><html lang="pt-BR"><head><title>Loja</title></head><body>
+<div id="progress-area" aria-live="polite">
+ <div id="upload-status" role="status"></div>
+</div>
+<main><p>Conteúdo.</p></main>
+</body></html>

--- a/benchmark/round2/run.py
+++ b/benchmark/round2/run.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""
+run.py — Round 2 collection runner (4 conditions, tag-archived treatments).
+
+Instrumentation for PROTOCOL-DRAFT.md — every behaviour here is dictated by
+the protocol; this file adds none. Frozen by hash before registration;
+collection opens only after the registration is public.
+
+    python3 run.py --plan
+    python3 run.py --agent claude-code --pinned-version "2.1.233 (Claude Code)" \
+                   --home /path/to/sanitized-home --resume
+    python3 run.py --agent claude-code --pinned-version ... --home ... --gate-probe
+    python3 run.py --self-test
+
+What the protocol dictates, implemented here:
+  * Conditions A · B · D18 (tag v1.8.0) · D20 (tag v2.0.0); slugs keep the
+    4-field shape agent__journey__COND__runN.
+  * Treatment = closed path list from `git archive <tag> -- docs/en/A11Y.md
+    docs/en/references docs/en/templates tools`, laid out exactly like Round
+    1's workspaces (A11Y.md, references/, templates/ — plus tools/ — at the
+    workspace root). Per-condition SHA-256 over the archive's files
+    concatenated in path order is computed at start, printed by --plan and
+    written into every log record.
+  * Interleaved collection: for each run index 1..N, conditions run in the
+    order A, B, D18, D20 before the next index — including under --resume.
+  * Version pinning: --pinned-version is required for collection; the client
+    version is re-read before EVERY run and the runner aborts on mismatch
+    (auto-update mid-collection is the failure this guards against).
+  * Sanitized HOME: --home is required for collection; the subprocess runs
+    with HOME (and USERPROFILE) pointed there; the path is logged per run.
+  * Retention (mechanical): a run is retained iff it produces 7 non-empty
+    screens within the 90-minute clock. Not-retained is DATA, not a retry.
+  * Retry (mechanical, infra only): non-zero exit AND zero screens produced
+    → retry, max 2; timeouts never retry; every attempt's raw output and log
+    record are preserved (nothing deleted).
+  * Gate probe (--gate-probe): one B-style single-screen probe per agent,
+    stored under probes/, with the audit instruction printed — retained only
+    if the transcript shows no reference to, or search for, the standard or
+    the operator's files (audited by grep + human eye, journaled).
+
+Stdlib only. One run = one fresh workspace + one fresh session + the whole
+journey prompt, verbatim from ../study2/PROMPTS.md.
+"""
+import argparse, hashlib, io, json, os, shutil, subprocess, sys, tarfile, tempfile, time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+S2 = REPO / "benchmark" / "study2"
+OUT = REPO / "benchmark" / "runs" / "round2"
+TIMEOUT_S = 90 * 60
+CONDITIONS = ("A", "B", "D18", "D20")   # interleaving order within each index
+TAGS = {"D18": "v1.8.0", "D20": "v2.0.0"}
+TREATMENT_PATHS = ("docs/en/A11Y.md", "docs/en/references", "docs/en/templates", "tools")
+RUNS_DEFAULT = 5
+MAX_RETRIES = 2
+
+RULE = ("When developing the frontend, follow strictly the accessibility rules "
+        "defined in A11Y.md: ./A11Y.md\n")
+GENERIC = "Make it accessible.\n\n"
+
+PROBE_PROMPT = (GENERIC +
+    "Build the home page of a small online bookstore called \"Loop Books\" as a "
+    "static site: a single index.html with plain HTML, CSS and JavaScript, no "
+    "build step, no external libraries or fonts. Header with the site name, "
+    "main navigation, and a grid of six featured book cards (cover image, "
+    "title, author, price, \"Add to cart\" button) from realistic hardcoded "
+    "data.")
+
+AGENTS = {
+    "claude-code": {
+        "rule_file": "CLAUDE.md",
+        "version": ["claude", "--version"],
+        "command": lambda prompt: ["claude", "-p", prompt, "--output-format", "json",
+                                   "--permission-mode", "acceptEdits"],
+    },
+    # Reserve naming per protocol; command shape inherited unchanged from the
+    # Round-1 swap entry (fresh profile via --home, --new-project per run,
+    # rule as prompt preamble per ARM2.md's bridge-cell translation).
+    "antigravity": {
+        "rule_file": None,
+        "prompt_rule": True,
+        "version": ["agy", "--version"],
+        "command": lambda prompt: ["agy", "-p", prompt,
+                                   "--model", "gemini-3.5-flash",
+                                   "--effort", "low",
+                                   "--output-format", "json",
+                                   "--mode", "accept-edits",
+                                   "--print-timeout", "90m",
+                                   "--new-project"],
+    },
+}
+# Codex rule (closed in the protocol): skip — quota resets 2026-09-16,
+# colliding with the calendar; named a Round-3 candidate. Not listed above.
+
+
+def journey_prompt() -> str:
+    text = (S2 / "PROMPTS.md").read_text()
+    return text[text.index("## `bookstore-journey`"):].split("\n", 1)[1].strip()
+
+
+def archive_bytes(tag: str) -> bytes:
+    r = subprocess.run(["git", "-C", str(REPO), "archive", tag, "--"] + list(TREATMENT_PATHS),
+                       capture_output=True)
+    if r.returncode != 0:
+        sys.exit(f"git archive {tag} failed: {r.stderr.decode(errors='replace').strip()}")
+    return r.stdout
+
+
+def treatment_hash(tar_bytes: bytes) -> str:
+    """SHA-256 over the archive's file contents concatenated in path order —
+    the per-condition hash the registration carries."""
+    h = hashlib.sha256()
+    with tarfile.open(fileobj=io.BytesIO(tar_bytes)) as tf:
+        members = sorted((m for m in tf.getmembers() if m.isfile()), key=lambda m: m.name)
+        for m in members:
+            h.update(tf.extractfile(m).read())
+    return h.hexdigest()
+
+
+def build_workspace(condition: str, parent: Path, rule_file: str, archives: dict):
+    """Fresh workspace per run. D conditions are laid out like Round 1's:
+    A11Y.md, references/, templates/ at the root — plus the tag's tools/."""
+    ws = Path(tempfile.mkdtemp(prefix=f"round2-{condition}-", dir=parent))
+    if condition in TAGS:
+        with tarfile.open(fileobj=io.BytesIO(archives[condition])) as tf:
+            tf.extractall(ws, filter="data")
+        en = ws / "docs" / "en"
+        (en / "A11Y.md").rename(ws / "A11Y.md")
+        for d in ("references", "templates"):
+            if (en / d).is_dir(): (en / d).rename(ws / d)
+        shutil.rmtree(ws / "docs")
+        # tools/ (when the tag has it) is already at the root — the standard
+        # points at tools/contrast-check.py relative to the workspace root.
+        if rule_file:
+            (ws / rule_file).write_text(RULE, encoding="utf-8")
+    seeded = {str(p.relative_to(ws)) for p in ws.rglob("*") if p.is_file()}
+    return ws, seeded
+
+
+def client_version(agent: dict, env: dict) -> str:
+    r = subprocess.run(agent["version"], capture_output=True, text=True, env=env)
+    return r.stdout.strip()
+
+
+def collect_produced(ws: Path, seeded: set, dest: Path):
+    dest.mkdir(parents=True, exist_ok=True)
+    produced = []
+    for p in sorted(ws.rglob("*")):
+        if not p.is_file(): continue
+        rel = str(p.relative_to(ws))
+        if rel in seeded or rel.split("/")[0].startswith("."): continue
+        tgt = dest / rel
+        tgt.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(p, tgt)
+        produced.append({"path": rel, "bytes": p.stat().st_size})
+    return produced
+
+
+def screens_in(produced: list) -> int:
+    return sum(1 for f in produced if f["path"].endswith(".html") and f["bytes"] > 0)
+
+
+def one_attempt(agent, full_prompt, ws, env):
+    t0 = time.time()
+    try:
+        r = subprocess.run(agent["command"](full_prompt), cwd=ws, capture_output=True,
+                           text=True, timeout=TIMEOUT_S, env=env)
+        raw = r.stdout
+        err = "" if r.returncode == 0 else f"exit {r.returncode}: {(r.stderr or r.stdout)[-500:].strip()}"
+        rc = r.returncode
+    except subprocess.TimeoutExpired:
+        raw, err, rc = "", "TIMEOUT 90m", None
+    return raw, err, rc, round(time.time() - t0, 1)
+
+
+def run_collection(args):
+    agent = AGENTS[args.agent]
+    prompt = journey_prompt()
+    archives = {c: archive_bytes(t) for c, t in TAGS.items()}
+    hashes = {c: treatment_hash(archives[c]) for c in TAGS}
+
+    jobs = [(c, r) for r in range(1, args.runs + 1) for c in CONDITIONS]
+    def slug(c, r): return f"{args.agent}__journey__{c}__run{r}"
+    if args.resume:
+        jobs = [j for j in jobs if not (OUT / "raw" / f"{slug(*j)}.json").is_file()]
+
+    print(f"{len(jobs)} run(s) · agent: {args.agent}")
+    for c in TAGS:
+        print(f"  treatment {c} = {TAGS[c]} · sha256 {hashes[c]}")
+    if args.plan:
+        for j in jobs: print(f"  {slug(*j)}")
+        return 0
+
+    if not args.pinned_version:
+        sys.exit("collection requires --pinned-version (the registered client version)")
+    if not args.home:
+        sys.exit("collection requires --home (the sanitized per-agent HOME)")
+    env = {**os.environ, "HOME": args.home, "USERPROFILE": args.home}
+
+    (OUT / "raw").mkdir(parents=True, exist_ok=True)
+    (OUT / "screens").mkdir(parents=True, exist_ok=True)
+    scratch = Path(tempfile.mkdtemp(prefix="round2-workspaces-"))
+    log = OUT / "log.jsonl"
+
+    for i, (condition, run) in enumerate(jobs, 1):
+        name = slug(condition, run)
+        version = client_version(agent, env)
+        if version != args.pinned_version:
+            sys.exit(f"ABORT before {name}: client version {version!r} != pinned "
+                     f"{args.pinned_version!r} (protocol: version changes only between "
+                     f"complete cycles, logged)")
+        print(f"[{i}/{len(jobs)}] {name}", flush=True)
+
+        full = (GENERIC + prompt) if condition == "B" else prompt
+        if condition in TAGS and agent.get("prompt_rule"):
+            full = RULE + "\n" + full
+
+        for attempt in range(1, MAX_RETRIES + 2):
+            ws, seeded = build_workspace(condition, scratch, agent["rule_file"], archives)
+            raw, err, rc, elapsed = one_attempt(agent, full, ws, env)
+            produced = collect_produced(ws, seeded, OUT / "screens" / name)
+            screens = screens_in(produced)
+            infra = (rc is not None and rc != 0 and screens == 0)
+            final = (not infra) or (attempt == MAX_RETRIES + 1)
+            raw_name = f"{name}.json" if final else f"{name}__attempt{attempt}.json"
+            (OUT / "raw" / raw_name).write_text(raw or "{}", encoding="utf-8")
+            record = {"id": name, "agent": args.agent, "condition": condition, "run": run,
+                      "attempt": attempt, "agent_version": version,
+                      "treatment_sha256": hashes.get(condition),
+                      "home": args.home, "duration_s": elapsed,
+                      "collected_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+                      "screens": screens, "retained": final and screens == 7 and not err,
+                      "files_created": produced}
+            if err: record["error"] = err
+            with log.open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+            print(f"    attempt {attempt}: {elapsed/60:.1f} min · {screens} telas"
+                  + (f" · {err}" if err else "")
+                  + ("" if final else " · infra error — mechanical retry"), flush=True)
+            if final: break
+    return 0
+
+
+def run_gate_probe(args):
+    agent = AGENTS[args.agent]
+    if not args.home:
+        sys.exit("--gate-probe requires --home (the sanitized per-agent HOME)")
+    env = {**os.environ, "HOME": args.home, "USERPROFILE": args.home}
+    version = client_version(agent, env)
+    probes = OUT / "probes"; probes.mkdir(parents=True, exist_ok=True)
+    scratch = Path(tempfile.mkdtemp(prefix="round2-probe-"))
+    ws, seeded = build_workspace("A", scratch, agent["rule_file"], {})
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    name = f"{args.agent}__gate-probe__{stamp}"
+    print(f"gate probe: {name} (agent {version})")
+    raw, err, rc, elapsed = one_attempt(agent, PROBE_PROMPT, ws, env)
+    produced = collect_produced(ws, seeded, probes / name)
+    (probes / f"{name}.json").write_text(raw or "{}", encoding="utf-8")
+    (probes / f"{name}.meta.json").write_text(json.dumps(
+        {"id": name, "agent": args.agent, "agent_version": version, "home": args.home,
+         "duration_s": elapsed, "error": err or None,
+         "screens": screens_in(produced),
+         "collected_at": datetime.now(timezone.utc).isoformat(timespec="seconds")},
+        ensure_ascii=False, indent=1), encoding="utf-8")
+    print(f"  {elapsed/60:.1f} min · {screens_in(produced)} tela(s)" + (f" · {err}" if err else ""))
+    print("AUDIT (protocol): the agent's HOME passes only if the probe transcript "
+          "contains no reference to, or search for, the standard or the operator's "
+          "files. Grep the raw capture for e.g. 'A11Y', 'a11y', 'vault', 'readme', "
+          "'Documentos', then read it whole; journal the verdict in DEVIATIONS.md "
+          "before any retained run.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# --self-test: the mechanics against a synthetic 40-run fixture (fake client)
+# ---------------------------------------------------------------------------
+
+FAKE_CLIENT = r'''#!/usr/bin/env python3
+import json, os, sys
+from pathlib import Path
+if "--version" in sys.argv:
+    print(os.environ.get("FAKE_VERSION", "fake 1.0.0")); sys.exit(0)
+marker = Path(os.environ["FAKE_STATE"]) / "fail-once"
+if marker.is_file():
+    marker.unlink()
+    sys.stderr.write("simulated infra failure: connection reset\n")
+    sys.exit(2)
+n = int(os.environ.get("FAKE_SCREENS", "7"))
+for i in range(n):
+    Path(f"screen{i}.html").write_text(f"<html><body>tela {i}</body></html>")
+print(json.dumps({"ok": True}))
+'''
+
+def self_test():
+    global OUT, TIMEOUT_S
+    ok = True
+    def check(name, got, want):
+        nonlocal ok
+        good = got == want
+        ok = ok and good
+        print(f"  {name}: got {got!r} want {want!r} {'ok' if good else 'SELF-TEST FAILURE'}")
+
+    td = Path(tempfile.mkdtemp(prefix="round2-selftest-"))
+    fake = td / "fake-client.py"
+    fake.write_text(FAKE_CLIENT); fake.chmod(0o755)
+    state = td / "state"; state.mkdir()
+    home = td / "home"; home.mkdir()
+    os.environ["FAKE_STATE"] = str(state)
+    os.environ["FAKE_VERSION"] = "fake 1.0.0"
+
+    AGENTS["fake"] = {
+        "rule_file": "CLAUDE.md",
+        "version": [sys.executable, str(fake), "--version"],
+        "command": lambda prompt: [sys.executable, str(fake), prompt],
+    }
+    out_orig = OUT
+    OUT = td / "out"
+
+    print("treatment archives — layout and per-condition hash:")
+    archives = {c: archive_bytes(t) for c, t in TAGS.items()}
+    h1 = {c: treatment_hash(archives[c]) for c in TAGS}
+    h2 = {c: treatment_hash(archive_bytes(t)) for c, t in TAGS.items()}
+    check("hash deterministic across re-archives", h1, h2)
+    check("D18 and D20 hashes differ", h1["D18"] != h1["D20"], True)
+    ws, seeded = build_workspace("D20", td, "CLAUDE.md", archives)
+    check("D20 root layout", sorted(p.name for p in ws.iterdir()),
+          sorted(["A11Y.md", "references", "templates", "tools", "CLAUDE.md"]))
+    check("D20 ships the contrast tool", (ws / "tools" / "contrast-check.py").is_file(), True)
+    ws18, _ = build_workspace("D18", td, "CLAUDE.md", archives)
+    check("D18 has no contrast tool (the asymmetry IS the treatment)",
+          (ws18 / "tools" / "contrast-check.py").is_file(), False)
+    check("A workspace is empty of treatment",
+          build_workspace("A", td, "CLAUDE.md", archives)[1], set())
+
+    print("interleaving — order and resume:")
+    jobs = [(c, r) for r in range(1, 6) for c in CONDITIONS]
+    check("20 jobs per agent (40 total across the 2 agents)", len(jobs), 20)
+    check("first cycle order", jobs[:4], [("A",1),("B",1),("D18",1),("D20",1)])
+    check("second cycle starts after full first", jobs[4], ("A", 2))
+
+    print("collection mechanics on the synthetic fixture (fake client, 20 runs/agent):")
+    class A: pass
+    a = A(); a.agent = "fake"; a.runs = 5; a.plan = False; a.resume = False
+    a.pinned_version = "fake 1.0.0"; a.home = str(home)
+    TIMEOUT_S = 60
+    rc = run_collection(a)
+    check("run_collection exits 0", rc, 0)
+    log_lines = [json.loads(l) for l in (OUT / "log.jsonl").read_text().splitlines()]
+    check("20 records", len(log_lines), 20)
+    check("all retained (7 screens, no error)", all(r["retained"] for r in log_lines), True)
+    check("interleaved order in the log",
+          [r["condition"] for r in log_lines[:4]], ["A", "B", "D18", "D20"])
+    check("D records carry the treatment hash",
+          all(r["treatment_sha256"] == h1[r["condition"]] for r in log_lines
+              if r["condition"] in TAGS), True)
+    check("A/B records carry no treatment hash",
+          all(r["treatment_sha256"] is None for r in log_lines
+              if r["condition"] not in TAGS), True)
+    check("HOME logged on every record", all(r["home"] == str(home) for r in log_lines), True)
+
+    print("resume — skips existing, preserves order:")
+    (OUT / "raw" / "fake__journey__A__run1.json").is_file() or check("raw exists", False, True)
+    a.resume = True
+    jobs_left = [(c, r) for r in range(1, 6) for c in CONDITIONS
+                 if not (OUT / "raw" / f"fake__journey__{c}__run{r}.json").is_file()]
+    check("nothing left after full collection", jobs_left, [])
+
+    print("mechanical retry — infra failure retried, everything preserved:")
+    (state / "fail-once").write_text("")
+    shutil.rmtree(OUT); a.resume = False; a.runs = 1
+    rc = run_collection(a)
+    log_lines = [json.loads(l) for l in (OUT / "log.jsonl").read_text().splitlines()]
+    check("first job failed once then succeeded",
+          [r["attempt"] for r in log_lines[:2]], [1, 2])
+    check("failed attempt logged, not retained",
+          (log_lines[0]["retained"], "error" in log_lines[0]), (False, True))
+    check("failed attempt's raw preserved",
+          (OUT / "raw" / "fake__journey__A__run1__attempt1.json").is_file(), True)
+    check("retained attempt's raw at the canonical name",
+          (OUT / "raw" / "fake__journey__A__run1.json").is_file(), True)
+
+    print("retention — short runs are data, never retried:")
+    os.environ["FAKE_SCREENS"] = "5"
+    shutil.rmtree(OUT); a.runs = 1
+    rc = run_collection(a)
+    log_lines = [json.loads(l) for l in (OUT / "log.jsonl").read_text().splitlines()]
+    check("5-screen run logged once (no retry), not retained",
+          [(r["attempt"], r["retained"]) for r in log_lines[:1]], [(1, False)])
+    os.environ["FAKE_SCREENS"] = "7"
+
+    print("version pinning — mismatch aborts before running:")
+    a.pinned_version = "fake 9.9.9"
+    shutil.rmtree(OUT)
+    try:
+        run_collection(a); check("abort on version mismatch", "no exit", "SystemExit")
+    except SystemExit as e:
+        check("abort on version mismatch", "ABORT" in str(e.code), True)
+
+    OUT = out_orig
+    print("self-test:", "PASS" if ok else "FAIL")
+    sys.exit(0 if ok else 1)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--agent", default="claude-code", choices=sorted(AGENTS))
+    ap.add_argument("--runs", type=int, default=RUNS_DEFAULT)
+    ap.add_argument("--plan", action="store_true")
+    ap.add_argument("--resume", action="store_true")
+    ap.add_argument("--pinned-version", default=None,
+                    help="registered client version; runner aborts if the live client differs")
+    ap.add_argument("--home", default=None,
+                    help="sanitized per-agent HOME (required for collection and probes)")
+    ap.add_argument("--gate-probe", action="store_true",
+                    help="run the B-style contamination probe instead of collecting")
+    ap.add_argument("--self-test", action="store_true")
+    args = ap.parse_args()
+    if args.self_test:
+        self_test()
+    if args.gate_probe:
+        return run_gate_probe(args)
+    return run_collection(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What this is

The complete Round-2 instrument set from the frozen protocol's checklist (#70) — every ruler and runner as executable, self-tested code, built under the review panel's rules: nothing here is frozen or registered yet; freezing happens by hash only after Felipe's OK on the pilot.

## The consistency ruler v2 (the delicate piece)

`classifier_v2.py` + `CLASSIFIER-v2.md` + 40 held-out fixtures. Two hardening stages, both **before any Round-2 data exists**:

1. **Calibration** — four independent agents audited the four suspected v1 defects against Round 1's 30 published journeys. All confirmed and fixed: the capability gate stops punishing honest `aria-sort` (all 10 D journeys carried +1 for doing the right thing); the two-lane card detector sees the JS-rendered catalogs (v1: 3/30 runs; v2: 30/30); the validity gate excludes broken composites instead of counting them as conventions (exactly 7 instances in one run, zero elsewhere); richness travels beside the excess so zero-because-uniform and zero-because-poor stop looking identical.
2. **Adversarial verification, twice** — an independent panel (gaming / condition-bias / regression lenses, skeptic re-verification per finding) attacked the draft: **16 findings confirmed and fixed**, 27 attacks survived. A **second panel round then attacked the fixes themselves**: **13 more confirmed and fixed**, 26 attacks survived. Both ledgers are in the spec. The two with measured real-corpus impact ran in opposite directions — a regex-literal lexer bug understated a non-treatment cell, a nested live-region double-count overstated a treatment cell — and both were verified by hand against the raw files before fixing.

Sensitivity on Round 1's corpus (v1 → v2, variant excess): antigravity A 0→2 (the "perfect zero" was blindness), B 20→11 (+2 card cells declared unmeasurable rather than falsely zero), D 21→9 (+7 exclusions); claude-code A 21→11, B 18→11, D 18→7. Shifts run in both directions and track content, not condition — the second hardening round raised both claude-code non-A cells. **Reading rule registered:** ruler 4 informs the primary D20-vs-D18 contrast only; cross-vocabulary sums are barred from secondary-contrast headlines (`analyze.py` enforces it mechanically).

Self-test: 58 checks — real-corpus anchors, mechanical condition-blindness (same bytes under A-named and D-named dirs), and 42 synthetic counterfactuals including everything both panel rounds built. Deterministic across re-runs, hash seeds and `-O`. Parser amendments (browser-faithful duplicate-attribute and HTML5 auto-close) measured judgment-neutral: 0 report diffs across all 45 run dirs.

## The rest of the checklist

- **`RULERS.md`** — frozen definitions of rulers 1–3/5 + the kill-class derivation (native rules in, keyboard rules out, with the why of each boundary).
- **`run.py`** — 4 conditions; treatment via `git archive` of the tags with per-condition SHA-256 (path-order concatenation) printed and logged; interleaving by run index incl. `--resume`; version pinning re-checked before EVERY run with abort; mandatory sanitized `--home`, logged; mechanical retry (infra only, ≤2, nothing deleted); 7-screen/90-min retention as data; `--gate-probe` for the contamination symptom. Self-test: 25 checks incl. the treatment asymmetry (D20 ships `tools/contrast-check.py`, D18 doesn't — that IS the treatment).
- **`analyze.py`** — primary D20−D18 per agent, journey-cluster bootstrap (seeded, B=10k), Cliff's delta, no p-values; the full canonical panel (floors, contrast bet, kill + 2×2, governance pair) with two-agent adjudication where the less favorable verdict leads. Self-test: 21 checks over a synthetic 40-run fixture with a favorable and an unfavorable planted twin — every panel branch fires.
- **`build_home.py`** — the auditable sanitized-HOME builder answering the Round-1 leakage entry: closed allow-list, fresh minimal settings (no grants, no extra dirs), MANIFEST with per-file hashes for the frozen snapshot.
- **`PROTOCOL-DRAFT.md`** — two pre-freeze amendments with paper trail: the `classifier_v2.py` filename (importability) and the ruler-4 cross-vocabulary rule.

## What this PR does NOT do

No freeze, no hashes recorded, no OSF submission, no collection. Next steps after merge, in order: build the real HOMEs → gate probes → pilot (1 discarded journey/agent, D20 affordance probe) → freeze by hash → registration package for your OSF submission → collection with the dated DEVIATIONS entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
