### PR TITLE
Round 2: the release's tool must be runnable — narrow grant, pilot re-run, tool path measured end to end

### DIFF
--- a/benchmark/round2/PILOT.md
+++ b/benchmark/round2/PILOT.md
@@ -79,7 +79,43 @@ agent, before the freeze. Pilot artifacts live under
 `runs/round2/pilot/` — outside `raw/`/`screens/`, so `--resume` can never
 confuse them with retained journeys.
 
-### claude-code (`claude-code__pilot__D20__20260830T115745Z`, client 2.1.237)
+### claude-code, pilot 2 — after the tool-runnability amendment
+### (`claude-code__pilot__D20__20260830T133007Z`, client 2.1.237)
+
+**Why a second pilot:** reviewing pilot 1's affordance record, the author
+ruled that packaging the release's tool without the ability to execute it
+contradicts his standing directive — the contrast checker was born from
+the earlier studies' findings, and "everything that came after must be
+tested". Pre-freeze amendment (protocol §Design, dated 2026-08-30): the
+sanitized HOME pre-approves executing exactly `tools/contrast-check.py`
+and nothing else, uniform across conditions; it simulates the approval an
+interactive user gives. HOME rebuilt (`claude-code-2`, grant in the
+MANIFEST), gate probe re-run: **PASS**
+(`probes/claude-code__gate-probe__20260830T132753Z*` — zero symptom
+terms, zero denials).
+
+**Pilot 2 result — the tool path is now measured end to end:**
+
+- 34.3 min · 7 screens · 34 files · 115 turns.
+- **The tool EXECUTED.** The REPORT states every declared pair was
+  *measured with `tools/contrast-check.py`* (matrix in
+  `A11Y-DECISIONS.md`; e.g. 16.52:1 / 15.25:1 / 11.46:1; lowest text pair
+  4.24:1 identified as border-only; lowest UI pair 3.97:1), and the agent
+  additionally ran the tool's CSS-triage mode, explaining its one flag
+  (a modal backdrop, not a text colour).
+- **The grant stayed narrow:** 10 remaining `permission_denials`, all
+  non-tool commands (a python one-liner mkdir, absolute-path variants) —
+  one command allowed, everything else still denied.
+- **§7 honesty intact:** the REPORT still separates "code and arithmetic
+  verified" from "rendering not seen", keeps unrun validators listed and
+  ownership assigned.
+- **Registration statement:** for Claude Code, D20 measures the TOOL path
+  (with the formula as the standard's fallback); for Antigravity, the
+  FORMULA path by construction — both official paths covered, one per
+  agent, stated per-agent, never pooled.
+
+### claude-code, pilot 1 — superseded by the amendment, kept as the record
+### that surfaced it (`claude-code__pilot__D20__20260830T115745Z`, client 2.1.237)
 
 - 28.1 min · 7 screens · 19 files · 88 turns — pace consistent with
   Round 1 (median 26–33 min).

--- a/benchmark/round2/PROTOCOL-DRAFT.md
+++ b/benchmark/round2/PROTOCOL-DRAFT.md
@@ -54,14 +54,29 @@ study** on the journey unit. Motivation cited, not an outcome promoted.
   (`tools/` at v1.8.0 has no `contrast-check.py`) **is the treatment** —
   release-as-delivered, both sides. Per-condition SHA-256 over the archive's
   files concatenated in path order enters the registration.
-- **Shell affordance is measured, not assumed.** The runner invokes Claude
-  Code with the same permission mode as Round 1 (unchanged, for harness
-  comparability) — a mode that does not auto-approve Bash. The pilot
-  therefore runs **one D20 journey per agent** and records the observed
-  affordance (shell granted? tool executed? formula path taken?) in the
-  journal before the freeze. If an agent cannot run the tool, the protocol
-  declares: for that agent, D20 measures the formula path by construction —
-  the fallback the standard itself prescribes.
+- **Shell affordance is measured, not assumed — and the release's own tool
+  must be RUNNABLE (pre-freeze amendment, 2026-08-30).** The first pilot
+  measured the inherited Round-1 permission mode: the agent asked to run
+  `tools/contrast-check.py` four times and was denied every time — the
+  tool travelled in the treatment but could not execute, which contradicts
+  this section's own rationale ("testing the release without its tool
+  would test a hypothetical") and the author's standing directive
+  (everything born from the earlier studies' findings must be tested).
+  Resolution: the sanitized HOME's settings pre-approve executing
+  **exactly that script and nothing else** (four spellings covering
+  relative/absolute invocation; grant listed in the frozen MANIFEST).
+  The grant is **uniform across all four conditions** — A/B/D18 receive
+  the same permission but ship no such file, so the asymmetry remains the
+  treatment — and it simulates the approval an interactive user gives
+  when the agent asks to run the standard's own tool; the fully-denying
+  non-interactive mode was the harness artifact, not the ecology. The
+  pilot re-runs under the grant and records the observed affordance
+  before the freeze. For an agent whose client offers no equivalent
+  narrow grant (Antigravity), the protocol declares: D20 measures the
+  formula path by construction — the fallback the standard itself
+  prescribes; with both agents, the study then measures BOTH of the
+  standard's official paths, one per agent, stated per-agent in the
+  registration and never pooled.
 - **Agents (2):** Claude Code and Antigravity, client versions named at
   registration. **Codex rule (closed):** Codex enters only if its quota is
   active and the client installable on freeze day; its quota resets

--- a/benchmark/round2/build_home.py
+++ b/benchmark/round2/build_home.py
@@ -50,10 +50,26 @@ ALLOW = {
 }
 
 # Written fresh into the sanitized HOME (never copied from the real one):
-# a minimal settings file with NO permission grants, NO additional
-# directories, NO hooks — so the leakage channel cannot re-enter by copy.
+# a minimal settings file with NO hooks, NO additional directories, and a
+# single narrow permission — so the leakage channel cannot re-enter by
+# copy. The one grant (author's directive, 2026-08-30, pre-freeze:
+# "everything that came after must be tested" — the contrast checker was
+# born from the earlier studies' findings): pre-approve executing
+# tools/contrast-check.py and nothing else. The grant is UNIFORM across
+# conditions; only the D20 workspace ships the file, so the asymmetry
+# remains the treatment. It simulates the approval an interactive user
+# gives when the agent asks to run the standard's own tool; both spellings
+# cover the cwd-relative and absolute-path invocations the pilot observed.
 CLAUDE_SETTINGS = {
-    "permissions": {"allow": [], "deny": []},
+    "permissions": {
+        "allow": [
+            "Bash(python3 tools/contrast-check.py:*)",
+            "Bash(python tools/contrast-check.py:*)",
+            "Bash(python3 */tools/contrast-check.py:*)",
+            "Bash(python */tools/contrast-check.py:*)",
+        ],
+        "deny": [],
+    },
 }
 
 


### PR DESCRIPTION
Executes Felipe's ruling on pilot 1: v2.0.0's contrast checker was travelling in the treatment but could not execute under the inherited Round-1 permission mode — which contradicts the protocol's own rationale and the standing directive (the tool was born from the earlier studies' findings; everything that came after must be tested).

**The amendment (pre-freeze, dated, full paper trail):**
- Sanitized HOME pre-approves **exactly `tools/contrast-check.py` and nothing else** — uniform across all four conditions (A/B/D18 get the same grant but ship no such file, so the asymmetry remains the treatment); it simulates the approval an interactive user gives when the agent asks to run the standard's own tool.
- Gate probe re-run under the rebuilt HOME: **PASS** (zero symptom terms, zero denials).
- **Pilot 2 measured the tool path end to end:** the tool executed; the REPORT states every declared pair was *measured with the tool* (full matrix in DECISIONS — 16.52:1/11.46:1/…, lowest text pair identified as border-only, CSS-triage flag explained); the grant stayed narrow (10 remaining denials, all non-tool commands); §7's honesty mechanics intact (arithmetic-vs-rendering split, unrun validators listed).
- Registration statement: **both official paths of the standard are now measured, one per agent** — tool (Claude Code), formula (Antigravity) — stated per-agent, never pooled. Pilot 1 stays in the journal as the record that surfaced the gap.

Next after merge: freeze by hash, OSF package, collection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)